### PR TITLE
user external services consent

### DIFF
--- a/src/user_consent.py
+++ b/src/user_consent.py
@@ -1,9 +1,28 @@
 import sys
 
+# Data consent messages
 CONSENT_HEADER = "\nData Usage Consent\n" + "-" * 50
-CONSENT_REQUEST = "We need your permission to use the data you will upload in our system.\nThis data will be processed and analyzed as part of our mining system."
+CONSENT_REQUEST = """We need your permission to use the data you will upload in our system.
+This data will be processed and analyzed as part of our mining system.
+"""
 CONSENT_PROMPT = "\nDo you consent to allow us to use your data? (yes/no): "
 CONSENT_GRANTED = "\n✓ Thank you! Consent granted for data usage."
+
+# External services consent messages
+EXTERNAL_HEADER = "\nExternal Services Consent\n" + "-" * 50
+EXTERNAL_REQUEST = """We can enhance our analysis using external services (e.g., LLM).
+
+Privacy Implications:
+- Data may be processed by third-party services
+- Enhanced analysis capabilities
+- Strict data handling protocols followed
+- External processing is optional"""
+EXTERNAL_PROMPT = "\nDo you consent to allow external services processing? (yes/no): "
+EXTERNAL_GRANTED = "\n✓ Thank you! Your data will be processed with enhanced external services."
+EXTERNAL_DENIED = "\nYou've chosen to proceed without external services. Analysis will be limited to local processing only."
+EXTERNAL_DENIED_CONFIRM = "\nDo you want to continue with basic analysis (without external services)? (yes/no): "
+
+# General messages
 CONSENT_DENIED_WARNING = "\n⚠️  Without consent, we cannot proceed with data processing."
 CONFIRM_EXIT_PROMPT = "Are you sure you want to exit? (yes/no): "
 EXIT_MESSAGE = "\nThank you for your time. Exiting system."
@@ -14,72 +33,141 @@ CONSENT_REVOKED = "\n⚠️  Consent has been revoked. Data access is now restri
 
 class UserConsent:
     def __init__(self):
-        """Initialize consent manager with default consent as False."""
-        self.has_consent = False
+        """Initialize consent manager with default consent values as False."""
+        self.has_data_consent = False
+        self.has_external_consent = False
 
     def ask_for_consent(self) -> bool:
         """
-        Ask user for consent to use their data.
+        Ask user for consent to use their data and optionally use external services.
         Handles the consent flow with retry logic for invalid inputs.
 
         Returns:
-            bool: True if user gave consent, False if user denied
+            bool: True if user gave at least data consent, False if user denied completely
+        """
+        # First ask for data consent
+        if not self._ask_for_data_consent():
+            return False
+
+        # If data consent granted, ask for external services consent
+        if not self._ask_for_external_consent():
+            return False  # User chose to exit when declining external services
+
+        return True
+
+    def _ask_for_data_consent(self) -> bool:
+        """
+        Ask user for data usage consent.
+        
+        Returns:
+            bool: True if user gave consent, False if denied
         """
         while True:
-            # Show consent information
             print(CONSENT_HEADER)
             print(CONSENT_REQUEST)
             consent_answer = input(CONSENT_PROMPT).lower().strip()
 
             if consent_answer in ['yes', 'y']:
-                self.has_consent = True
+                self.has_data_consent = True
                 print(CONSENT_GRANTED)
                 return True
 
             elif consent_answer in ['no', 'n']:
-                # Ask for confirmation to exit
                 while True:
                     print(CONSENT_DENIED_WARNING)
                     confirm_exit = input(CONFIRM_EXIT_PROMPT).lower().strip()
 
                     if confirm_exit in ['yes', 'y']:
-                        self.has_consent = False
+                        self.has_data_consent = False
                         print(EXIT_MESSAGE)
                         return False
                     elif confirm_exit in ['no', 'n']:
-                        # User doesn't want to exit, loop back to consent question
                         print(RETRY_MESSAGE)
-                        break  # Break inner loop to go back to main consent question
+                        break
                     else:
                         print(INVALID_INPUT)
-                continue  # Continue outer loop to ask consent again
+                continue
             
             else:
                 print(INVALID_INPUT)
-                continue  # Explicitly continue to ask the question again
+                continue
 
-    def check_consent(self) -> bool:
+    def _ask_for_external_consent(self) -> bool:
         """
-        Check if we have user consent.
+        Ask user for external services consent.
+        Only called after data consent is granted.
+        
+        Returns:
+            bool: True if user wants to continue (with or without external services),
+                 False if user wants to exit completely
+        """
+        print(EXTERNAL_HEADER)
+        print(EXTERNAL_REQUEST)
+        
+        while True:
+            external_answer = input(EXTERNAL_PROMPT).lower().strip()
+
+            if external_answer in ['yes', 'y']:
+                self.has_external_consent = True
+                print(EXTERNAL_GRANTED)
+                return True
+
+            elif external_answer in ['no', 'n']:
+                self.has_external_consent = False
+                print(EXTERNAL_DENIED)
+                
+                while True:
+                    continue_answer = input(EXTERNAL_DENIED_CONFIRM).lower().strip()
+                    
+                    if continue_answer in ['yes', 'y']:
+                        # User wants to continue with basic analysis
+                        return True
+                    elif continue_answer in ['no', 'n']:
+                        # User wants to exit completely
+                        self.has_data_consent = False
+                        print(EXIT_MESSAGE)
+                        return False
+                    else:
+                        print(INVALID_INPUT)
+            
+            else:
+                print(INVALID_INPUT)
+                continue
+
+    def check_consent(self) -> tuple[bool, bool]:
+        """
+        Check if we have user consent for data usage and external services.
 
         Returns:
-            bool: True if we have consent, False otherwise
+            tuple[bool, bool]: (data_consent, external_consent)
         """
-        return self.has_consent
+        return self.has_data_consent, self.has_external_consent
 
-    def revoke_consent(self):
-        """Revoke previously granted consent."""
-        self.has_consent = False
+    def revoke_consent(self, include_external: bool = True):
+        """
+        Revoke previously granted consent.
+        
+        Args:
+            include_external (bool): If True, also revoke external services consent
+        """
+        self.has_data_consent = False
+        if include_external:
+            self.has_external_consent = False
         print(CONSENT_REVOKED)
 
 
 if __name__ == "__main__":
     consent_manager = UserConsent()
     
-    # First check if we already have consent
-    if not consent_manager.check_consent():
-        # If no consent, ask for it
-        if not consent_manager.ask_for_consent():
-            sys.exit(1)
+    # Ask for consent if we don't have it
+    if not consent_manager.ask_for_consent():
+        sys.exit(1)
     
-    print("Proceeding with system operations...")
+    # Get final consent status
+    data_consent, external_consent = consent_manager.check_consent()
+    
+    # Show appropriate message based on consent levels
+    if external_consent:
+        print("\nProceeding with system operations using external services...")
+    else:
+        print("\nProceeding with basic system operations (no external services)...")


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

Added external services consent functionality to the existing consent system. This enhancement allows users to optionally consent to using external services (e.g., LLM) for enhanced analysis while maintaining data privacy controls.

- Separate external services consent prompt
- Clear privacy implications displayed for external processing
- Option to proceed with basic analysis if external services are declined
- State management for external services consent
- Ability to revoke external consent separately

**Closes:** #72 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Updated the previous test cases to take care of all possible scenarios for consent flow testing, input validation and error handling for both data and external services consent.
All tests can be run by 'python test/test_user_consent.py -v'.


---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<img width="648" height="394" alt="Screenshot 2025-10-19 at 6 14 08 PM" src="https://github.com/user-attachments/assets/7acb8b77-54d4-455c-b097-608d2a7cd939" />

<img width="603" height="380" alt="Screenshot 2025-10-19 at 6 14 44 PM" src="https://github.com/user-attachments/assets/3c25250b-5f4e-4065-8365-f79f4d562564" />


</details>
