### PR TITLE
Pathing change quick fix

### DIFF
--- a/test/test_extraction.py
+++ b/test/test_extraction.py
@@ -146,7 +146,7 @@ class TestExtraction(unittest.TestCase):
         - Correct error text is returned when file is not zip
         """
         path = os.path.join(self.original_cwd, "test")
-        path = os.path.join(path, "TestZips")
+        path = os.path.join(path, "TestZIPs")
         path = os.path.join(path, "test.txt")
         extractInfo_instance = extractInfo(path)
         text = extractInfo_instance.verifyZIP()
@@ -161,7 +161,7 @@ class TestExtraction(unittest.TestCase):
         - Correct error text is returned when zip file is bad
         """
         path = os.path.join(self.original_cwd, "test")
-        path = os.path.join(path, "TestZips")
+        path = os.path.join(path, "TestZIPs")
         path = os.path.join(path, "TEST.zip")
         extractInfo_instance = extractInfo(path)
         text = extractInfo_instance.verifyZIP()
@@ -177,7 +177,7 @@ class TestExtraction(unittest.TestCase):
         - Non-zip file isn't marked as bad zip file
         """
         path = os.path.join(self.original_cwd, "test")
-        path = os.path.join(path, "TestZips")
+        path = os.path.join(path, "TestZIPs")
         path = os.path.join(path, "test.txt")
         extractInfo_instance = extractInfo(path)
         text = extractInfo_instance.verifyZIP()
@@ -205,7 +205,7 @@ class TestExtraction(unittest.TestCase):
         - Correct error text is returned when file is not zip
         """
         path = os.path.join(self.original_cwd, "test")
-        path = os.path.join(path, "TestZips")
+        path = os.path.join(path, "TestZIPs")
         path = os.path.join(path, "test.txt")
         extractInfo_instance = extractInfo(path)
         text = extractInfo_instance.runExtraction()
@@ -220,7 +220,7 @@ class TestExtraction(unittest.TestCase):
         - Correct error text is returned when zip file is bad
         """
         path = os.path.join(self.original_cwd, "test")
-        path = os.path.join(path, "TestZips")
+        path = os.path.join(path, "TestZIPs")
         path = os.path.join(path, "TEST.zip")
         extractInfo_instance = extractInfo(path)
         text = extractInfo_instance.runExtraction()


### PR DESCRIPTION
## 📝 Description

Changed pathing definition in test_extraction.py to use os to define path instead of slashes and backslashes so linux and macos have no issues.

Does not close a defined board issue

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Running pytest test/test_extraction.py on a linux or macos system proves fix. Running on windows ensures fix didn't break anything.

- [x] Running pytest test/test_extraction.py on linux or macos system

---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [ ] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile
