### PR TITLE
Enhance CLI project insights with shared helpers, composite ranking, …

### DIFF
--- a/src/insight_helpers.py
+++ b/src/insight_helpers.py
@@ -1,0 +1,86 @@
+"""
+Shared helpers for working with project insights.
+
+Responsibilities:
+- Parse dates into timezone-aware datetimes
+- Filter insight objects by language, skill, or recency
+- Compute composite scores that combine contributions, recency, and skill breadth
+
+These are used by menu_insights and can be reused anywhere we need consistent
+insight filtering and scoring logic.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable
+
+def parse_date(value: str | None) -> datetime | None:
+    """Parse a date/datetime string into a timezone-aware datetime in UTC."""
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+    except Exception:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+def filter_insights(
+    insights: Iterable,
+    *,
+    language: str | None = None,
+    skill: str | None = None,
+    since: datetime | None = None,
+):
+    """Filter insight objects by language, skill, and a minimum analyzed_at timestamp."""
+    language_l = language.lower() if language else None
+    skill_l = skill.lower() if skill else None
+    filtered = []
+    for ins in insights:
+        if language_l and all(language_l != lang.lower() for lang in ins.languages):
+            continue
+        if skill_l and all(skill_l != skl.lower() for skl in ins.skills):
+            continue
+
+        if since:
+            analyzed = parse_date(ins.analyzed_at)
+            if analyzed and analyzed < since:
+                continue
+        filtered.append(ins)
+    return filtered
+
+def compute_composite_score(
+    insight,
+    *,
+    contributor: str | None = None,
+    recency_weight: float = 10.0,
+    skill_weight: float = 0.5,
+) -> tuple[float, dict]:
+    """
+    Compute a composite score that favors contribution strength, recency, and skill breadth.
+
+    Returns:
+        (score, parts) where parts contains individual components for display.
+    """
+    base = insight.contribution_score(contributor)
+    skill_bonus = len(insight.skills) * skill_weight
+
+    analyzed = parse_date(insight.analyzed_at)
+    recency_bonus = 0.0
+    age_days = None
+    if analyzed:
+        age_days = max(0, (datetime.now(timezone.utc) - analyzed).days)
+        # Linear decay over one year
+        recency_bonus = max(0.0, recency_weight * (1 - min(age_days, 365) / 365))
+
+    score = base + recency_bonus + skill_bonus
+    return score, {
+        "base": base,
+        "recency": recency_bonus,
+        "skills": skill_bonus,
+        "age_days": int(age_days) if age_days is not None else None,
+    }
+
+__all__ = ["parse_date", "filter_insights", "compute_composite_score"]

--- a/src/menu_insights.py
+++ b/src/menu_insights.py
@@ -1,0 +1,220 @@
+"""
+Menu for browsing stored project insights: chronology, skills, rankings, and summaries.
+
+Provides an interactive CLI loop that:
+- Lists projects chronologically with stack and summaries
+- Shows skill timelines with optional filtering
+- Ranks projects via composite scoring (contrib + recency + skills)
+- Surfaces top-ranked summaries with rationale
+
+Kept separate from menus.py to keep navigation wiring lean.
+"""
+
+from pathlib import Path
+
+from src.project_insights import (
+    list_project_insights,
+    list_skill_history,
+    rank_projects_by_contribution,
+    summaries_for_top_ranked_projects,
+)
+from src.insight_helpers import parse_date, filter_insights, compute_composite_score
+
+def project_insights_menu(ctx) -> None:
+    """
+    View stored project insights: chronological projects, skill history, rankings, and top summaries.
+
+    Uses the JSON log at User_config_files/project_insights.json to present:
+      - Chronological projects (oldest to newest) with type and stack
+      - Chronological skills exercised per project
+      - Contribution-based ranking (optionally filtered by contributor)
+      - Top-ranked project summaries with scores
+    """
+    storage_path = Path(ctx.legacy_save_dir) / "project_insights.json"
+
+    while True:
+        print("\n=== Project Insights ===")
+        print("1) Chronological list of projects")
+        print("2) Chronological list of skills")
+        print("3) Rank projects by contribution")
+        print("4) Summaries for top-ranked projects")
+        print("0) Exit to Main Menu")
+
+        choice = input("Select an option: ").strip()
+
+        try:
+            if choice == "1":
+                language = input("Filter by language (optional): ").strip() or None
+                skill = input("Filter by skill (optional): ").strip() or None
+                since_str = input("Only include analyses since (YYYY-MM-DD, optional): ").strip() or None
+                since_dt = parse_date(since_str)
+
+                projects = list_project_insights(storage_path=storage_path)
+                projects = filter_insights(
+                    projects,
+                    language=language,
+                    skill=skill,
+                    since=since_dt,
+                )
+
+                if not projects:
+                    print("[INFO] No insights recorded yet.")
+                else:
+                    print("\nProjects (oldest → newest):\n")
+                    for i, p in enumerate(projects, start=1):
+                        langs = ", ".join(p.languages) or "—"
+                        frws = ", ".join(p.frameworks) or "—"
+                        summary = p.summary or "—"
+                        print(
+                            f"{i}) {p.project_name} | analyzed_at={p.analyzed_at} | "
+                            f"type={p.project_type} ({p.detection_mode}) | "
+                            f"langs={langs} | frameworks={frws}\n"
+                            f"    summary: {summary}"
+                        )
+                input("\nPress Enter to continue...")
+
+            elif choice == "2":
+                skill = input("Filter by skill (optional): ").strip() or None
+                since_str = input("Only include analyses since (YYYY-MM-DD, optional): ").strip() or None
+                since_dt = parse_date(since_str)
+
+                history = list_skill_history(storage_path=storage_path)
+                if since_dt or skill:
+                    filtered = []
+                    for entry in history:
+                        when = parse_date(entry.get("analyzed_at"))
+                        if since_dt and when and when < since_dt:
+                            continue
+                        if skill and all(skill.lower() != s.lower() for s in entry.get("skills", [])):
+                            continue
+                        filtered.append(entry)
+                    history = filtered
+
+                if not history:
+                    print("[INFO] No insights recorded yet.")
+                else:
+                    print("\nSkills (chronological):\n")
+                    for entry in history:
+                        skills = ", ".join(entry.get("skills", [])) or "—"
+                        print(
+                            f"- {entry.get('project_name', 'unknown')} "
+                            f"@ {entry.get('analyzed_at', 'unknown')} "
+                            f"| skills ({entry.get('skill_count', 0)}): {skills}"
+                        )
+                input("\nPress Enter to continue...")
+
+            elif choice == "3":
+                contributor = input("Filter by contributor (leave blank for overall ranking): ").strip() or None
+                language = input("Filter by language (optional): ").strip() or None
+                skill = input("Filter by skill (optional): ").strip() or None
+                since_str = input("Only include analyses since (YYYY-MM-DD, optional): ").strip() or None
+                since_dt = parse_date(since_str)
+                top_n_raw = input("How many projects to show? [default 5]: ").strip()
+                try:
+                    top_n = int(top_n_raw) if top_n_raw else 5
+                except ValueError:
+                    print("[INFO] Invalid number; defaulting to 5.")
+                    top_n = 5
+
+                ranked = list_project_insights(storage_path=storage_path)
+                ranked = filter_insights(
+                    ranked,
+                    language=language,
+                    skill=skill,
+                    since=since_dt,
+                )
+                if contributor:
+                    ranked = rank_projects_by_contribution(
+                        storage_path=storage_path,
+                        contributor=contributor,
+                        top_n=None,
+                    )
+                    ranked = filter_insights(ranked, language=language, skill=skill, since=since_dt)
+
+                ranked = sorted(
+                    ranked,
+                    key=lambda ins: compute_composite_score(ins, contributor=contributor)[0],
+                    reverse=True,
+                )
+                if top_n >= 0:
+                    ranked = ranked[:top_n]
+
+                if not ranked:
+                    print("[INFO] No insights recorded yet.")
+                else:
+                    print("\nProject ranking:\n")
+                    for i, item in enumerate(ranked, start=1):
+                        score, parts = compute_composite_score(item, contributor=contributor)
+                        reason = (
+                            f"base={parts['base']}, "
+                            f"recency={parts['recency']:.2f}, "
+                            f"skills={parts['skills']:.2f}"
+                        )
+                        print(
+                            f"{i}) {item.project_name} | composite={score:.2f} | "
+                            f"contributors={item.stats.get('contributors')} | {reason}"
+                        )
+                input("\nPress Enter to continue...")
+
+            elif choice == "4":
+                contributor = input("Filter by contributor (leave blank for overall ranking): ").strip() or None
+                language = input("Filter by language (optional): ").strip() or None
+                skill = input("Filter by skill (optional): ").strip() or None
+                since_str = input("Only include analyses since (YYYY-MM-DD, optional): ").strip() or None
+                since_dt = parse_date(since_str)
+                top_n_raw = input("How many top projects to summarize? [default 3]: ").strip()
+                try:
+                    top_n = int(top_n_raw) if top_n_raw else 3
+                except ValueError:
+                    print("[INFO] Invalid number; defaulting to 3.")
+                    top_n = 3
+
+                insights = list_project_insights(storage_path=storage_path)
+                insights = filter_insights(
+                    insights,
+                    language=language,
+                    skill=skill,
+                    since=since_dt,
+                )
+                if contributor:
+                    insights = rank_projects_by_contribution(
+                        storage_path=storage_path,
+                        contributor=contributor,
+                        top_n=None,
+                    )
+                    insights = filter_insights(insights, language=language, skill=skill, since=since_dt)
+
+                summaries = sorted(
+                    insights,
+                    key=lambda ins: compute_composite_score(ins, contributor=contributor)[0],
+                    reverse=True,
+                )
+                summaries = summaries[:top_n] if top_n >= 0 else []
+
+                if not summaries:
+                    print("[INFO] No insights recorded yet.")
+                else:
+                    print("\nTop-ranked project summaries:\n")
+                    for i, insight in enumerate(summaries, start=1):
+                        score, parts = compute_composite_score(insight, contributor=contributor)
+                        rationale = (
+                            f"base={parts['base']}, recency={parts['recency']:.2f}, "
+                            f"skills={parts['skills']:.2f}"
+                        )
+                        print(
+                            f"{i}) {insight.project_name} | composite={score:.2f}"
+                        )
+                        print(f"    summary: {insight.summary or '—'}")
+                        print(f"    rationale: {rationale}")
+                input("\nPress Enter to continue...")
+
+            elif choice == "0":
+                return
+
+            else:
+                print("Please choose a valid option (0-4).")
+
+        except Exception as e:
+            print(f"[ERROR] {e}")
+            input("Press Enter to return to insights menu...")
+            return

--- a/src/menus.py
+++ b/src/menus.py
@@ -1,3 +1,14 @@
+"""
+CLI menus for configuration, consent aware analysis, saved reports, and project insights.
+
+Entrypoints here stitch together user facing flows:
+- settings: configure consent and defaults
+- analyze: ingest a directory or ZIP (with optional AI analysis when consented)
+- saved/delete: review or remove persisted analyses
+- AI portfolio/resume: regenerate AI driven summaries when external services are permitted
+- insights: view chronological projects/skills, rankings, and top summaries from stored insights
+"""
+
 from pathlib import Path
 import json
 
@@ -17,6 +28,8 @@ from src.saved_projects import (
     list_saved_projects,
     show_saved_summary,
 )
+from src.menu_insights import project_insights_menu
+
 from src.user_startup_config import ConfigLoader
 from src.Generate_AI_Resume import GenerateProjectResume
 
@@ -308,7 +321,8 @@ def main_menu(ctx: AppContext) -> int:
         ctx (AppContext): Shared DB/store context.
 
     Returns:
-        int: Exit code (0 on normal exit).
+        int: Exit code (0 on normal exit). Includes options for settings, analysis,
+             saved/deletion flows, portfolio/resume generation, and insights viewing.
     """
     while True:
         print("\n=== Main Menu ===")
@@ -318,6 +332,7 @@ def main_menu(ctx: AppContext) -> int:
         print("4) Delete analysis")
         print("5) AI Portfolio Generator")
         print("6) AI Resume Line Generator")
+        print("7) Project insights")
         print("0) Exit")
         choice = input("Select an option: ").strip()
 
@@ -334,11 +349,13 @@ def main_menu(ctx: AppContext) -> int:
                 get_portfolio_menu(ctx)
             elif choice == "6":
                 ai_resume_line_menu(ctx)
+            elif choice == "7":
+                project_insights_menu(ctx)
             elif choice == "0":
                 print("Goodbye!")
                 return 0
             else:
-                print("Please choose a valid option (0-6).")
+                print("Please choose a valid option (0-7).")
         except KeyboardInterrupt:
             print("\n[Interrupted] Returning to menu.")
         except Exception as e:
@@ -380,7 +397,7 @@ def ai_resume_line_menu(ctx: AppContext) -> None:
         print(f"{i}) {p.name}")
 
     sel = input(
-        "\nChoose a file to generate an AI résumé line from (or 0 to cancel): "
+        "\nChoose a file to generate an AI resume line from (or 0 to cancel): "
     ).strip()
     if not sel or sel == "0":
         return
@@ -410,13 +427,13 @@ def ai_resume_line_menu(ctx: AppContext) -> None:
     try:
         ai_item = GenerateProjectResume(project_root).generate(saveToJson=False)
     except Exception as e:
-        print(f"[ERROR] Could not generate AI résumé line: {e}")
+        print(f"[ERROR] Could not generate AI resume line: {e}")
         return
 
     # Print a tight résumé-style line + minimal context
     print("\n========================================")
     print(f"Project: {ai_item.project_title or Path(project_root).name}")
     print("----------------------------------------")
-    print("Résumé line:")
+    print("Resume line:")
     print(f"  • {ai_item.one_sentence_summary}")
     print("========================================\n")

--- a/test/test_menus.py
+++ b/test/test_menus.py
@@ -1,13 +1,20 @@
+"""
+Menu flow tests for the CLI and insights menu, including helper coverage.
+Exercises the primary user paths plus the shared insight helpers used by the menu flows.
+"""
+
 from pathlib import Path
 from types import SimpleNamespace
+from datetime import datetime, timezone, timedelta
 
 import pytest
 
 # Smoke tests for menu dispatch flows using monkeypatched input.
 import src.menus as mod
-
+from src import insight_helpers
 
 def _inputs(values):
+    """Yield successive inputs to simulate user interaction across menu prompts."""
     it = iter(values)
 
     def fake_input(prompt=""):
@@ -18,8 +25,8 @@ def _inputs(values):
 
     return fake_input
 
-
 def test_analyze_project_menu_directory_invokes_analyze(monkeypatch):
+    """Directory option routes to analyze_project with input path."""
     called = {}
     monkeypatch.setattr("builtins.input", _inputs(["1"]))
     monkeypatch.setattr(mod, "input_path", lambda prompt, allow_blank=False: Path("/tmp/project"))
@@ -36,8 +43,8 @@ def test_analyze_project_menu_directory_invokes_analyze(monkeypatch):
 
     assert called["path"] == Path("/tmp/project")
 
-
 def test_analyze_project_menu_zip_invokes_extract_and_analyze(monkeypatch):
+    """ZIP option extracts then analyzes with ZIP stem as project label."""
     called = {}
     monkeypatch.setattr("builtins.input", _inputs(["2"]))
     monkeypatch.setattr(mod, "input_path", lambda prompt, allow_blank=False: Path("/tmp/project.zip"))
@@ -58,8 +65,8 @@ def test_analyze_project_menu_zip_invokes_extract_and_analyze(monkeypatch):
     assert called["data"][0] == Path("/tmp/unzipped")
     assert called["data"][1] == "project"
 
-
 def test_saved_projects_menu_shows_selected_file(monkeypatch):
+    """Saved projects menu lists items and calls show_saved_summary."""
     item = Path("/tmp/a.json")
     monkeypatch.setattr(mod, "list_saved_projects", lambda folder: [item])
     monkeypatch.setattr(mod, "show_saved_summary", lambda path: None)
@@ -68,8 +75,8 @@ def test_saved_projects_menu_shows_selected_file(monkeypatch):
     ctx = SimpleNamespace(default_save_dir=Path("/tmp/default"), external_consent=False)
     mod.saved_projects_menu(ctx)
 
-
 def test_delete_analysis_menu_deletes(monkeypatch, tmp_path):
+    """Delete menu removes DB record for the chosen file."""
     file_path = tmp_path / "demo.json"
     file_path.write_text("{}")
 
@@ -90,14 +97,26 @@ def test_delete_analysis_menu_deletes(monkeypatch, tmp_path):
     assert delete_calls["id"] == 1
 
 def test_main_menu_exit_returns_zero(monkeypatch):
+    """Selecting 0 exits main menu with status code 0."""
     monkeypatch.setattr("builtins.input", _inputs(["0"]))
     result = mod.main_menu(SimpleNamespace())
     assert result == 0
+
+def test_main_menu_routes_to_insights_menu(monkeypatch):
+    """Option 7 should dispatch to project_insights_menu."""
+    called = {}
+    monkeypatch.setattr("builtins.input", _inputs(["7", "0"]))
+    monkeypatch.setattr(mod, "project_insights_menu", lambda ctx: called.setdefault("hit", True))
+    mod.main_menu(SimpleNamespace())
+    assert called.get("hit") is True
 
 def test_ai_resume_line_menu_no_external_consent(monkeypatch, tmp_path):
     """
     If 'consented.external' is False in UserConfigs.json,
     the AI résumé menu should NOT call list_saved_projects or GenerateProjectResume.
+
+    Verifies:
+    - Consent gating short-circuits downstream calls
     """
     # Create a fake UserConfigs.json with external consent = False
     config_path = tmp_path / "UserConfigs.json"
@@ -137,6 +156,10 @@ def test_ai_resume_line_menu_with_external_consent_and_selection(monkeypatch, tm
     """
     When external consent is True and the user selects a saved project,
     the menu should call GenerateProjectResume(project_root).generate(saveToJson=False).
+
+    Verifies:
+    - The chosen project_root flows into GenerateProjectResume
+    - generate() is invoked with saveToJson=False
     """
     import json
 
@@ -169,6 +192,7 @@ def test_ai_resume_line_menu_with_external_consent_and_selection(monkeypatch, tm
     calls = {"project_root": None, "saveToJson": None}
 
     class FakeGPR:
+        """Minimal stub for GenerateProjectResume to track call parameters."""
         def __init__(self, root):
             calls["project_root"] = root
 
@@ -195,3 +219,127 @@ def test_ai_resume_line_menu_with_external_consent_and_selection(monkeypatch, tm
     assert calls["project_root"] == project_root
     # And that generate() was called with saveToJson=False
     assert calls["saveToJson"] is False
+
+def test_project_insights_menu_lists_projects(monkeypatch, tmp_path):
+    """Insights menu lists projects from storage path."""
+    storage = tmp_path / "project_insights.json"
+    ctx = SimpleNamespace(legacy_save_dir=tmp_path)
+
+    captured_path = {}
+
+    def fake_list_projects(storage_path):
+        captured_path["path"] = storage_path
+        return [
+            SimpleNamespace(
+                project_name="Demo",
+                analyzed_at="2024-01-01",
+                project_type="individual",
+                detection_mode="git",
+                languages=["Python"],
+                frameworks=["FastAPI"],
+            )
+        ]
+
+    import src.menu_insights as mi
+    monkeypatch.setattr(mi, "list_project_insights", fake_list_projects)
+    monkeypatch.setattr(mi, "list_skill_history", lambda storage_path: [])
+    monkeypatch.setattr(mi, "rank_projects_by_contribution", lambda **kwargs: [])
+    monkeypatch.setattr(mi, "summaries_for_top_ranked_projects", lambda **kwargs: [])
+    # choice=1, language="", skill="", since="", enter to continue, then exit
+    monkeypatch.setattr("builtins.input", _inputs(["1", "", "", "", "", "0"]))
+
+    mod.project_insights_menu(ctx)
+    assert captured_path["path"] == storage
+
+def test_project_insights_menu_ranks_projects(monkeypatch, tmp_path):
+    """
+    Insights menu should honor contributor filters and composite scoring.
+
+    Verifies:
+    - rank_projects_by_contribution is invoked when contributor is provided
+    - Composite ranking prefers more recent, higher-skill items
+    """
+    storage = tmp_path / "project_insights.json"
+    ctx = SimpleNamespace(legacy_save_dir=tmp_path)
+
+    captured_rank = {}
+    # create two insights with different dates and skills to ensure composite sorting works
+    now = datetime.now(timezone.utc)
+    recent = now.isoformat()
+    old = (now - timedelta(days=200)).isoformat()
+
+    insights = [
+        SimpleNamespace(
+            project_name="OldLow",
+            stats={"contributors": 1},
+            contribution_score=lambda c=None: 1,
+            languages=["Python"],
+            frameworks=[],
+            skills=["SQL"],
+            summary="Old project",
+            analyzed_at=old,
+        ),
+        SimpleNamespace(
+            project_name="NewHigh",
+            stats={"contributors": 2},
+            contribution_score=lambda c=None: 2,
+            languages=["Java"],
+            frameworks=[],
+            skills=["Java", "Spring"],
+            summary="New project",
+            analyzed_at=recent,
+        ),
+    ]
+
+    def fake_rank(storage_path, contributor=None, top_n=None):
+        captured_rank["called"] = True
+        return insights
+
+    # Patch inside menu_insights module so delegation picks up the fake
+    import src.menu_insights as mi
+    monkeypatch.setattr(mi, "rank_projects_by_contribution", fake_rank)
+    monkeypatch.setattr(mi, "list_project_insights", lambda storage_path: insights)
+    monkeypatch.setattr(mi, "list_skill_history", lambda storage_path: [])
+    monkeypatch.setattr(mi, "summaries_for_top_ranked_projects", lambda **kwargs: [])
+    # choice=3, contributor="Alice" (forces rank_projects_by_contribution), language blank, skill blank, since blank, top_n=5, enter to continue, exit
+    monkeypatch.setattr("builtins.input", _inputs(["3", "Alice", "", "", "", "5", "", "0"]))
+
+    mod.project_insights_menu(ctx)
+    assert captured_rank.get("called") is True
+    # Verify composite ranking prefers newer project with more skills
+    scores = [
+        insight_helpers.compute_composite_score(insights[0])[0],
+        insight_helpers.compute_composite_score(insights[1])[0],
+    ]
+    assert scores[1] > scores[0]
+
+def test_insight_helper_filter_and_score_smoke():
+    """Quick sanity checks for filter_insights and compute_composite_score helpers."""
+    now = datetime.now(timezone.utc)
+    old = now - timedelta(days=400)
+
+    recent = SimpleNamespace(
+        analyzed_at=now.isoformat(),
+        languages=["Python"],
+        skills=["ML", "Data"],
+        contribution_score=lambda c=None: 1,
+    )
+    stale = SimpleNamespace(
+        analyzed_at=old.isoformat(),
+        languages=["Java"],
+        skills=["DevOps"],
+        contribution_score=lambda c=None: 2,
+    )
+
+    filtered = insight_helpers.filter_insights([recent, stale], language="python")
+    assert filtered == [recent]
+
+    filtered = insight_helpers.filter_insights([recent, stale], skill="devops")
+    assert filtered == [stale]
+
+    filtered = insight_helpers.filter_insights([recent, stale], since=now - timedelta(days=30))
+    assert filtered == [recent]
+
+    score_recent, _ = insight_helpers.compute_composite_score(recent)
+    score_stale, _ = insight_helpers.compute_composite_score(stale)
+    assert score_recent > score_stale


### PR DESCRIPTION
…and a dedicated Insights menu

## 📝 Description

- Extract shared insight utilities (date parsing, filtering, composite scoring) into src/insight_helpers.py.  
- Add a dedicated insights menu under src/menu_insights.py to surface chronological projects, skill history, rankings, and top summaries.  
- Wire the main menu to expose the new insights flow.  
- Expanded and updated menu tests to cover the new insights menu and helper logic, with improved docstrings for clarity.
- Added clearer module and test docstrings to describe responsibilities and coverage.

**Closes:** #238 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- Verified the new insights flow both manually and through automated tests. 

### Automatic
- All relevant tests pass.
- pytest test/test_menus.py

### Manual
Launched the CLI locally and navigated to Project Insights, testing options 1–4. Confirmed that:
- Project lists render correctly  
- Skill timelines display accurately  
- Rankings are calculated and shown  
- Top summaries appear correctly  

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<img width="1272" height="69" alt="image" src="https://github.com/user-attachments/assets/90b8643c-2ece-494c-9410-6042487c2646" />


