### PR TITLE
289 add thumnail upload ability at project analysis point

### DIFF
--- a/src/cli/menus.py
+++ b/src/cli/menus.py
@@ -140,12 +140,13 @@ def toggle_external_services(ctx: AppContext) -> None:
     else:
         print("\n[INFO] Invalid option. No changes made.")
         
-def prompt_thumbnail_upload(project_name: str, ctx: AppContext) -> bool:
+def prompt_thumbnail_upload(project_id: str, project_name: str, ctx: AppContext) -> bool:
     """
     Prompt the user to upload a thumbnail for a project after analysis.
 
     Args:
-        project_name: Human-readable project name (used as thumbnail identifier).
+        project_id: UUID for storing the thumbnail (used as file identifier).
+        project_name: Human-readable project name (used for display messages).
         ctx: Application context containing storage paths.
 
     Returns:
@@ -168,7 +169,7 @@ def prompt_thumbnail_upload(project_name: str, ctx: AppContext) -> bool:
     while attempts < max_attempts:
         image_path_str = input("Enter path to thumbnail image (or 'cancel' to skip): ").strip()
         
-        if not image_path_str or image_path_str.lower() == 'cancel':
+        if image_path_str.lower() == 'cancel':
             print("[INFO] Thumbnail upload cancelled. You can add it later in Settings.")
             return False
         
@@ -192,9 +193,9 @@ def prompt_thumbnail_upload(project_name: str, ctx: AppContext) -> bool:
                 print(f"        {remaining} attempt(s) remaining.")
             continue
         
-        # Add the thumbnail using project_name as identifier
+        # Add the thumbnail using project_id (UUID) as identifier
         success, error, thumb_path = thumbnail_manager.add_thumbnail(
-            project_id=project_name,
+            project_id=project_id,
             image_path=image_path,
             resize=True
         )
@@ -202,6 +203,11 @@ def prompt_thumbnail_upload(project_name: str, ctx: AppContext) -> bool:
         if success:
             print(f"[SUCCESS] Thumbnail added for '{project_name}'")
             print(f"          Saved to: {thumb_path}")
+            
+            # Update project_insights.json with thumbnail info
+            storage_path = Path(ctx.legacy_save_dir) / "project_insights.json"
+            update_thumbnail_in_insights(project_id, thumb_path, storage_path)
+            
             return True
         else:
             attempts += 1
@@ -274,12 +280,28 @@ def analyze_project_menu(ctx: AppContext) -> None:
                 print("Please choose a valid option (0–2).")
                 continue
                 
-               # After successful analysis, prompt for thumbnail upload
+            # After successful analysis, prompt for thumbnail upload
             if project_name:
-                prompt_thumbnail_upload(
-                    project_name=project_name,
-                    ctx=ctx
-                )
+                # Get the UUID from the newly created insight
+                storage_path = Path(ctx.legacy_save_dir) / "project_insights.json"
+                insights = list_project_insights(storage_path=storage_path)
+                
+                # Find the most recent insight matching this project name
+                matching_insight = None
+                for insight in reversed(insights):  # Most recent first
+                    if insight.project_name == project_name:
+                        matching_insight = insight
+                        break
+                
+                if matching_insight:
+                    prompt_thumbnail_upload(
+                        project_id=matching_insight.id,
+                        project_name=project_name,
+                        ctx=ctx
+                    )
+                else:
+                    # Fallback if insight not found (shouldn't happen normally)
+                    print("[WARNING] Could not find project insight. Skipping thumbnail prompt.")
             
             return
         except KeyboardInterrupt:
@@ -763,7 +785,8 @@ def thumbnail_management_menu(ctx) -> None:
         ctx: Application context with storage paths
     """
     storage_path = Path(ctx.legacy_save_dir) / "project_insights.json"
-    thumbnail_manager = ThumbnailManager()
+    thumbnail_dir = Path(ctx.legacy_save_dir) / "thumbnails"
+    thumbnail_manager = ThumbnailManager(storage_dir=thumbnail_dir)
     
     if not storage_path.exists():
         print("[INFO] Initializing project insights from saved analyses...")

--- a/test/test_menus.py
+++ b/test/test_menus.py
@@ -58,9 +58,13 @@ def test_analyze_project_menu_zip_invokes_extract_and_analyze(monkeypatch):
             "data", (path, project_label)
         ),
     )
+    # mocks for the thumbnail flow
+    monkeypatch.setattr(mod, "list_project_insights", lambda storage_path: [])
+    monkeypatch.setattr(mod, "prompt_thumbnail_upload", lambda project_id, project_name, ctx: False)
 
     ctx = SimpleNamespace(
-        external_consent=False
+        external_consent=False,
+        legacy_save_dir=Path("/tmp")
     )
     mod.analyze_project_menu(ctx)
 
@@ -501,3 +505,156 @@ def _initialize_insights_from_saved_files(
         except Exception:
             # don't crash initialization if one file is malformed
             continue
+        
+def test_prompt_thumbnail_upload_success(monkeypatch, tmp_path):
+    """Test successful thumbnail upload flow."""
+    # Setup
+    thumbnail_dir = tmp_path / "thumbnails"
+    thumbnail_dir.mkdir()
+    
+    # Create a fake image file
+    fake_image = tmp_path / "test_image.png"
+    fake_image.write_bytes(b'\x89PNG\r\n\x1a\n' + b'\x00' * 100)  # Minimal PNG header
+    
+    storage_path = tmp_path / "project_insights.json"
+    storage_path.write_text('[{"id": "test-uuid-123", "project_name": "TestProject"}]')
+    
+    # Mock inputs: 'y' to add thumbnail, path to image
+    monkeypatch.setattr("builtins.input", _inputs(["y", str(fake_image)]))
+    
+    # Mock ThumbnailManager
+    mock_thumb_path = thumbnail_dir / "test-uuid-123.png"
+    monkeypatch.setattr(
+        mod,
+        "ThumbnailManager",
+        lambda storage_dir: SimpleNamespace(
+            validate_image=lambda p: (True, None),
+            add_thumbnail=lambda project_id, image_path, resize: (True, None, mock_thumb_path),
+        ),
+    )
+    
+    # Mock update_thumbnail_in_insights
+    called = {}
+    monkeypatch.setattr(
+        mod,
+        "update_thumbnail_in_insights",
+        lambda pid, path, spath: called.setdefault("called", (pid, path)),
+    )
+    
+    ctx = SimpleNamespace(legacy_save_dir=tmp_path)
+    
+    result = mod.prompt_thumbnail_upload("test-uuid-123", "TestProject", ctx)
+    
+    assert result is True
+    assert called["called"][0] == "test-uuid-123"
+
+
+def test_prompt_thumbnail_upload_declined(monkeypatch, tmp_path):
+    """Test user declining thumbnail upload."""
+    monkeypatch.setattr("builtins.input", _inputs(["n"]))
+    
+    ctx = SimpleNamespace(legacy_save_dir=tmp_path)
+    result = mod.prompt_thumbnail_upload("test-uuid", "TestProject", ctx)
+    
+    assert result is False
+
+
+def test_prompt_thumbnail_upload_cancelled(monkeypatch, tmp_path):
+    """Test user cancelling during path input."""
+    monkeypatch.setattr("builtins.input", _inputs(["y", "cancel"]))
+    
+    # Mock ThumbnailManager
+    monkeypatch.setattr(
+        mod,
+        "ThumbnailManager",
+        lambda storage_dir: SimpleNamespace(),
+    )
+    
+    ctx = SimpleNamespace(legacy_save_dir=tmp_path)
+    result = mod.prompt_thumbnail_upload("test-uuid", "TestProject", ctx)
+    
+    assert result is False
+
+
+def test_analyze_project_menu_directory_invokes_analyze(monkeypatch):
+    """Directory option routes to analyze_project with input path."""
+    called = {}
+    monkeypatch.setattr("builtins.input", _inputs(["1"]))
+    monkeypatch.setattr(mod, "input_path", lambda prompt, allow_blank=False: Path("/tmp/project"))
+    monkeypatch.setattr(
+        mod,
+        "analyze_project",
+        lambda path, ctx, use_ai_analysis=False: called.setdefault("path", path),
+    )
+    # Add these new mocks for the thumbnail flow
+    monkeypatch.setattr(mod, "list_project_insights", lambda storage_path: [])
+    monkeypatch.setattr(mod, "prompt_thumbnail_upload", lambda project_id, project_name, ctx: False)
+
+    ctx = SimpleNamespace(
+        external_consent=False,
+        legacy_save_dir=Path("/tmp")  # Add this
+    )
+    mod.analyze_project_menu(ctx)
+
+    assert called["path"] == Path("/tmp/project")
+
+def test_remove_thumbnail_workflow_unpacks_tuple_correctly(monkeypatch, tmp_path):
+    """Test that _remove_thumbnail_workflow correctly unpacks the (insight, thumb_path) tuple."""
+    storage_path = tmp_path / "project_insights.json"
+    
+    # Create mock insight with thumbnail
+    mock_insight = SimpleNamespace(
+        id="test-uuid",
+        project_name="TestProject",
+        thumbnail={"exists": True, "path": "/some/path.png"}
+    )
+    
+    monkeypatch.setattr(
+        mod,
+        "list_project_insights",
+        lambda storage_path: [mock_insight],
+    )
+    
+    # Track calls
+    called = {}
+    
+    mock_thumbnail_manager = SimpleNamespace(
+        get_thumbnail_path=lambda pid: Path("/fake/thumb.png") if pid == "test-uuid" else None,
+        delete_thumbnail=lambda pid: called.setdefault("deleted", pid) or True,
+    )
+    
+    monkeypatch.setattr(
+        mod,
+        "remove_thumbnail_from_insights",
+        lambda pid, spath: called.setdefault("removed", pid),
+    )
+    
+    # User selects project 1, confirms deletion
+    monkeypatch.setattr("builtins.input", _inputs(["1", "y", ""]))
+    
+    mod._remove_thumbnail_workflow(storage_path, mock_thumbnail_manager)
+    
+    assert called.get("deleted") == "test-uuid"
+    assert called.get("removed") == "test-uuid"
+
+
+def test_thumbnail_management_menu_uses_correct_storage_dir(monkeypatch, tmp_path):
+    """Ensure thumbnail_management_menu passes correct storage_dir to ThumbnailManager."""
+    captured = {}
+    
+    class MockThumbnailManager:
+        def __init__(self, storage_dir=None):
+            captured["storage_dir"] = storage_dir
+    
+    monkeypatch.setattr(mod, "ThumbnailManager", MockThumbnailManager)
+    monkeypatch.setattr("builtins.input", _inputs(["0"]))  # Exit immediately
+    
+    # Create the insights file so it doesn't try to initialize
+    storage_path = tmp_path / "project_insights.json"
+    storage_path.write_text("[]")
+    
+    ctx = SimpleNamespace(legacy_save_dir=tmp_path)
+    mod.thumbnail_management_menu(ctx)
+    
+    expected_dir = tmp_path / "thumbnails"
+    assert captured["storage_dir"] == expected_dir


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

1. > This PR adds the ability for the user add a thumbnail when they upload a project to be analyzed

**Closes:** # (289)

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Unittests: from root type pytest test/test_menus.py -v into the terminal window
> Manual tests: start program and from main menu go to 2) Analyze project and select directory or ZIP, When it asks to save as a JSON file select yes. When it asks if you want to add a thumbnail select yes and add a filepath for an image. Once it saves it should return you to the main menu. To double check the save go to 1) Settings, 3) Manage thumbnails. It should appear in both 1)Add/Update thumbnails and 2) remove thumbnails

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->
<img width="1551" height="738" alt="image" src="https://github.com/user-attachments/assets/eb4a5e2e-007b-4f53-b97a-a29660120db2" />


</details>
