### PR TITLE
User prompts added for Portfolio view

### DIFF
--- a/src/reporting/portfolio.py
+++ b/src/reporting/portfolio.py
@@ -49,76 +49,83 @@ def display_portfolio_and_generate_pdf(path: Path, ctx: AppContext) -> None:
         display_portfolio_showcase(ps)
         
         # PDF Prompt
-        #print("=" * 50)
-        generate_pdf_input = "Y" #input("Would you like to generate a PDF? (y/n): ").strip().upper()
-        
-        if generate_pdf_input == "Y":
-            name_of_file = (
-                input("Enter the name of the PDF file or press enter to use default name (Portfolio): ").strip()or "Portfolio")
+        print("=" * 50)
+        while True:
+            generate_pdf_input = input("Would you like to generate a PDF? (y/N): ").strip().upper()
             
-            # Collect folder path only for fallback (RenderCV uses its own output directory)
-            folder_path = None
-            try:
-                print("[INFO] Generating portfolio PDF using RenderCV...")
+            if generate_pdf_input in {"Y", "N", ""}:
+                break
+            print("[WARN] Please enter only 'y' or 'n'.")
+        
+        if generate_pdf_input != "Y":
+            return # Early exit if no PDF generation requested
+        
+        name_of_file = (
+            input("Enter the name of the PDF file or press enter to use default name (Portfolio): ").strip()or "Portfolio")
+            
+        # Collect folder path only for fallback (RenderCV uses its own output directory)
+        folder_path = None
+        try:
+            print("[INFO] Generating portfolio PDF using RenderCV...")
 
-                service = PortfolioRenderCVService(name=name_of_file)
-                service.add_portfolio(ps)
-                status, pdf_path = service.render_portfolio_pdf()
+            service = PortfolioRenderCVService(name=name_of_file)
+            service.add_portfolio(ps)
+            status, pdf_path = service.render_portfolio_pdf()
 
-                print(f"[INFO] RenderCV status: {status}")
-                if pdf_path:
-                    print(f"[INFO] Portfolio PDF generated at: {pdf_path}")
-                    save_custom = input("Save PDF to a custom location? (y/n): ").strip().upper()
-                    if save_custom == "Y":
-                        attempts = 0
-                        max_attempts = 3
-                        while attempts < max_attempts:
-                            custom_folder = input("Enter the folder path to save the PDF: ").strip()
-                            if os.path.exists(custom_folder):
-                                custom_path = Path(custom_folder) / pdf_path.name
-                                shutil.copy2(pdf_path, custom_path)
-                                print(f"[INFO] PDF saved to: {custom_path}")
-                                break
-                            else:
-                                print(f"[ERROR] Path not found: {custom_folder}")
-                                attempts += 1
+            print(f"[INFO] RenderCV status: {status}")
+            if pdf_path:
+                print(f"[INFO] Portfolio PDF generated at: {pdf_path}")
+                save_custom = input("Save PDF to a custom location? (y/N): ").strip().upper()
+                if save_custom == "Y":
+                    attempts = 0
+                    max_attempts = 3                        
+                    while attempts < max_attempts:
+                        custom_folder = input("Enter the folder path to save the PDF: ").strip()
+                        if os.path.exists(custom_folder):
+                            custom_path = Path(custom_folder) / pdf_path.name
+                            shutil.copy2(pdf_path, custom_path)
+                            print(f"[INFO] PDF saved to: {custom_path}")
+                            break
                         else:
+                            print(f"[ERROR] Path not found: {custom_folder}")                                
+                            attempts += 1
+                    else:
                             print("[WARN] Maximum attempts reached. PDF remains at default location.")
 
-            except Exception as e:
-                print(f"[WARN] RenderCV export failed, falling back to legacy PDF: {e}")
+        except Exception as e:
+            print(f"[WARN] RenderCV export failed, falling back to legacy PDF: {e}")
                 
-                # Collect folder path for fallback PDF generator
-                if folder_path is None:
-                    attempts = 0
-                    max_attempts = 3
-                    while attempts < max_attempts:
-                        folder_path = input("Enter the folder path where you want to save the PDF: ").strip()
-                        if os.path.exists(folder_path):
-                            break
-                        attempts += 1
-                    else:
-                        print("Maximum attempts reached. Cannot generate fallback PDF.")
-                        return
+            # Collect folder path for fallback PDF generator
+            if folder_path is None:
+                attempts = 0
+                max_attempts = 3
+                while attempts < max_attempts:
+                    folder_path = input("Enter the folder path where you want to save the PDF: ").strip()
+                    if os.path.exists(folder_path):
+                        break
+                    attempts += 1
+                else:
+                    print("Maximum attempts reached. Cannot generate fallback PDF.")
+                    return
                 
-                resume_item = analysis.get("resume_item") or {}
-                tech_stack_parts = []
-                if resume_item.get("languages"):
-                    tech_stack_parts.extend(resume_item.get("languages") or [])
-                if resume_item.get("frameworks"):
-                    tech_stack_parts.extend(resume_item.get("frameworks") or [])
+            resume_item = analysis.get("resume_item") or {}
+            tech_stack_parts = []
+            if resume_item.get("languages"):
+                tech_stack_parts.extend(resume_item.get("languages") or [])
+            if resume_item.get("frameworks"):
+                tech_stack_parts.extend(resume_item.get("frameworks") or [])
 
-                legacy_data = ResumeItem(
-                    project_title=resume_item.get("project_name", ps.title),
-                    one_sentence_summary=resume_item.get("summary", ps.overview),
-                    detailed_summary=ps.overview or resume_item.get("summary", ""),
-                    key_responsibilities=list(ps.technical_highlights or []),
-                    key_skills_used=list(resume_item.get("skills") or []),
-                    tech_stack=", ".join(tech_stack_parts),
-                    impact="",
-                    oop_principles_detected={},
-                )
-                SimpleResumeGenerator(folder_path, data=legacy_data, fileName=name_of_file).display_and_run(portfolio_only=True)
+            legacy_data = ResumeItem(
+                project_title=resume_item.get("project_name", ps.title),
+                one_sentence_summary=resume_item.get("summary", ps.overview),
+                detailed_summary=ps.overview or resume_item.get("summary", ""),
+                key_responsibilities=list(ps.technical_highlights or []),
+                key_skills_used=list(resume_item.get("skills") or []),
+                tech_stack=", ".join(tech_stack_parts),
+                impact="",
+                oop_principles_detected={},
+            )
+            SimpleResumeGenerator(folder_path, data=legacy_data, fileName=name_of_file).display_and_run(portfolio_only=True)
 
         return
     
@@ -152,7 +159,13 @@ def display_portfolio_and_generate_pdf(path: Path, ctx: AppContext) -> None:
         print("  (None detected)")
     print()
     
-    generate_pdf_input = input("Would you like to generate a PDF? (y/n): ").strip().upper()
+    while True:
+        generate_pdf_input = input("Would you like to generate a PDF? (y/N): ").strip().upper()
+            
+        if generate_pdf_input in {"Y", "N", ""}:
+            break
+        print("[WARN] Please enter only 'y' or 'n'.")
+        
     if generate_pdf_input == "Y":
         attempts = 0
         max_attempts = 3

--- a/test/test_portfolio.py
+++ b/test/test_portfolio.py
@@ -39,7 +39,8 @@ def test_display_portfolio_external_disabled_uses_saved_oop(monkeypatch, tmp_pat
     file_path.write_text(mod.json.dumps(data))
 
     # Mock input to skip PDF generation prompts
-    monkeypatch.setattr("builtins.input", lambda prompt="": "n")
+    inputs = iter(["n"])   # sequence of answers
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
 
     mod.display_portfolio_and_generate_pdf(file_path, ctx)
     out = capsys.readouterr().out
@@ -83,10 +84,88 @@ def test_display_portfolio_external_enabled_calls_generator(monkeypatch, tmp_pat
 
     monkeypatch.setattr(mod, "GenerateProjectResume", FakeResume)
     # Mock input to skip PDF generation prompts
-    monkeypatch.setattr("builtins.input", lambda prompt="": "n")
+    inputs = iter(["n"])   # sequence of answers
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
 
     mod.display_portfolio_and_generate_pdf(file_path, ctx)
     out = capsys.readouterr().out
 
     assert "PROJECT: DemoProj" in out
     assert "One-Sentence Summary: Summary" in out    
+    
+def test_display_portfolio_default_enter_skips_pdf(monkeypatch, tmp_path, capsys):
+    ctx = SimpleNamespace(legacy_save_dir=tmp_path / "User_config_files", external_consent=False)
+    ctx.legacy_save_dir.mkdir(parents=True)
+    (ctx.legacy_save_dir / "UserConfigs.json").write_text('{"consented": {"external": false}}')
+
+    data = {
+        "resume_item": {"project_name": "Demo", "summary": "Demo"},
+        "oop_analysis": {"score": {"oop_score": 0.5}},
+    }
+    file_path = tmp_path / "analysis.json"
+    file_path.write_text(mod.json.dumps(data))
+
+    # User presses ENTER (empty string)
+    inputs = iter([""])
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
+
+    mod.display_portfolio_and_generate_pdf(file_path, ctx)
+    out = capsys.readouterr().out
+
+    # Should show portfolio but not ask for filename
+    assert "PORTFOLIO SHOWCASE" in out
+    assert "Enter the name of the PDF" not in out
+    
+def test_display_portfolio_reprompts_on_invalid_input(monkeypatch, tmp_path, capsys):
+    ctx = SimpleNamespace(legacy_save_dir=tmp_path / "User_config_files", external_consent=False)
+    ctx.legacy_save_dir.mkdir(parents=True)
+    (ctx.legacy_save_dir / "UserConfigs.json").write_text('{"consented": {"external": false}}')
+
+    data = {
+        "resume_item": {"project_name": "Demo", "summary": "Demo"},
+        "oop_analysis": {"score": {"oop_score": 0.5}},
+    }
+    file_path = tmp_path / "analysis.json"
+    file_path.write_text(mod.json.dumps(data))
+
+    # First invalid, then valid "n"
+    inputs = iter(["maybe", "n"])
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
+
+    mod.display_portfolio_and_generate_pdf(file_path, ctx)
+    out = capsys.readouterr().out
+
+    assert "[WARN] Please enter only 'y' or 'n'." in out
+    
+def test_display_portfolio_yes_triggers_pdf_flow(monkeypatch, tmp_path, capsys):
+    ctx = SimpleNamespace(
+        legacy_save_dir=tmp_path / "User_config_files",
+        external_consent=False,
+    )
+    ctx.legacy_save_dir.mkdir(parents=True)
+    (ctx.legacy_save_dir / "UserConfigs.json").write_text(
+        '{"consented": {"external": false}}'
+    )
+
+    data = {
+        "resume_item": {"project_name": "Demo", "summary": "Demo"},
+        "oop_analysis": {"score": {"oop_score": 0.5}},
+    }
+    file_path = tmp_path / "analysis.json"
+    file_path.write_text(mod.json.dumps(data))
+
+    # Say yes, then provide filename
+    inputs = iter(["y", "TestPortfolio"])
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
+
+    try:
+        mod.display_portfolio_and_generate_pdf(file_path, ctx)
+    except Exception:
+        pass  
+
+    out = capsys.readouterr().out
+
+    assert "PORTFOLIO SHOWCASE" in out
+    assert "[INFO] Generating portfolio PDF using RenderCV..." in out
+
+


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

Previously, generate_pdf_input was hardcoded to "Y", forcing users into PDF generation and save path prompts even when they only wanted to view the portfolio summary. The fix respects user intent by making PDF generation optional.

**Closes:** #360 

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

pytest test/test_portfolio.py -v

Updated old tests and added new ones to make sure the system handles users' responses and allows the user to just view the summary instead of pushing for PDF by default. 


---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> 

<details>
<summary>Click to expand screenshots</summary>


<img width="942" height="325" alt="Screenshot 2026-02-02 at 2 08 43 PM" src="https://github.com/user-attachments/assets/70409a98-ed06-4c2d-894a-191a9c33598c" />


</details>
