### PR TITLE
Add AI project endpoints and fix backend validation/errors

### DIFF
--- a/src/API/Portfolio_Generator_API.py
+++ b/src/API/Portfolio_Generator_API.py
@@ -26,6 +26,9 @@ Endpoints:
     DELETE /portfolio/{id}                                - Delete the portfolio YAML file entirely
 """
 
+import re
+import pendulum
+import ruamel.yaml as _yaml
 from typing import Any, Optional, List
 from pathlib import Path
 import uuid
@@ -41,8 +44,12 @@ from src.reporting.portfolio_service import (
     save_project_role_override,
 )
 from src.core.app_context import runtimeAppContext
+from src.reporting.Generate_Resume_AI_Ver2 import GenerateResumeAI_Ver2
 
 RENDERED_OUTPUTS_DIR = Path(__file__).resolve().parents[2] / "User_config_files" / "Generate_render_CV_files" / "rendered_outputs"
+
+ALLOWED_CONTACT_FIELDS = {"email", "phone", "location", "website", "name"}
+SKIPPING_GENERATION = "Skipping generation"
 
 portfolioRouter = APIRouter(tags=["Portfolio"])
 
@@ -134,7 +141,7 @@ class ManualProjectRequest(BaseModel):
     highlights: Optional[list[str]] = None
 
 
-class  skillRequest(BaseModel):
+class SkillRequest(BaseModel):
     """Payload for adding a new a skill"""
     model_config = ConfigDict(json_schema_extra={
         "example":{
@@ -201,7 +208,7 @@ def _load_portfolio(name:str) -> RenderCVDocument:
         doc.load(name=name)
 
     except FileNotFoundError:
-        raise HTTPException(status_code=404,detail=f"Portfolio '{name}' not found'")
+        raise HTTPException(status_code=404, detail=f"Portfolio '{name}' not found")
 
     return doc
 
@@ -217,7 +224,7 @@ def _check_result(result:str):
     Raises:
         HTTPException: 400 if the result does not indicate success.
     """
-    if "Successfully" not in result:
+    if "successfully" not in result.lower():
         raise HTTPException(status_code=400,detail=result)
     return result
 
@@ -270,6 +277,30 @@ def get_portfolio_showcase_role(project_name: str):
     return {"project_name": project_name, "role": role}
 
 
+@portfolioRouter.get("/portfolios")
+def list_portfolios():
+    """List all saved portfolio IDs, display names, and creation dates.
+
+    Returns:
+        list[dict]: Each entry has 'id', 'name', and 'created_at' (ISO string or None).
+    """
+    cv_dir = Path(__file__).resolve().parents[2] / "User_config_files" / "Generate_render_CV_files"
+    results = []
+    y = _yaml.YAML()
+    for yaml_file in sorted(cv_dir.glob("*_Portfolio_CV.yaml")):
+        portfolio_id = yaml_file.stem.replace("_Portfolio_CV", "")
+        display_name = re.sub(r'_[0-9a-f]{8}$', '', portfolio_id).replace("_", " ")
+        created_at = None
+        try:
+            with open(yaml_file, "r") as f:
+                data = y.load(f)
+            created_at = data.get("created_at")
+        except Exception:
+            pass
+        results.append({"id": portfolio_id, "name": display_name, "created_at": created_at})
+    return results
+
+
 @portfolioRouter.post("/portfolio/generate")
 def generate_portfolio(payload: GeneratePortfolioRequest):
     """Create a new portfolio YAML document.
@@ -286,9 +317,9 @@ def generate_portfolio(payload: GeneratePortfolioRequest):
     """
     doc=RenderCVDocument(doc_type='portfolio')
     portfolio_id=str(uuid.uuid4())[:8]
-    full_name=f"{payload.name}_{portfolio_id}"
+    full_name=f"{payload.name.replace(' ', '_')}_{portfolio_id}"
     gen_result=doc.generate(name=full_name,overwrite=payload.overwrite)
-    if gen_result=="Skipping generation":
+    if gen_result == SKIPPING_GENERATION:
         raise HTTPException(status_code=409,detail=f"Portfolio {full_name} already exists. Set overwrite=true to replace it")
 
     doc.load(name=full_name)
@@ -298,6 +329,13 @@ def generate_portfolio(payload: GeneratePortfolioRequest):
             doc.update_theme(payload.theme)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
+
+    doc.data["created_at"] = pendulum.now("UTC").to_iso8601_string()
+    try:
+        with open(doc.yaml_file, "w") as f:
+            doc.yaml.dump(doc.data, f)
+    except OSError as e:
+        raise HTTPException(status_code=500, detail=f"Portfolio generated but failed to save metadata: {e}")
 
     return {"portfolio_id": full_name, "status": "Portfolio created successfully"}
 
@@ -370,7 +408,7 @@ def edit_portfolio(portfolio_id:str,payload: EditProjectRequest):
     Section-specific notes:
         - summary: Only `new_value` is used; `item_name` and `field` are ignored.
         - contact: Use `field` to specify which contact field to update (e.g., email, phone).
-        - theme: Only `new_value` is used; valid themes are 'sb2nov', 'classic', 'moderncv', 'engineeringresumes'.
+        - theme: Only `new_value` is used; valid themes are 'sb2nov', 'classic', 'moderncv', 'engineeringresumes', 'engineeringclassic'.
         - skills: Use `item_name` to identify the skill to rename; `new_value` is the new skill name.
         - projects: Use `item_name` for the project name, `field` for the attribute to change.
         - connections: Use `item_name` for network name, `field="username"` to add/modify, `field="delete"` to remove.
@@ -381,23 +419,28 @@ def edit_portfolio(portfolio_id:str,payload: EditProjectRequest):
         section=edit.section.lower()
 
         if section=="summary":
-            result= doc.update_summary(str(edit.new_value))
+            result = _check_result(doc.update_summary(str(edit.new_value)))
 
         elif section=="contact":
+            if edit.field not in ALLOWED_CONTACT_FIELDS:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Unknown contact field '{edit.field}'. Valid fields: {', '.join(sorted(ALLOWED_CONTACT_FIELDS))}"
+                )
             doc.update_contact(**{edit.field : edit.new_value})
             result = f"Successfully updated contact field '{edit.field}'"
 
         elif section == "theme":
             try:
-                result=doc.update_theme(str(edit.new_value))
+                result = _check_result(doc.update_theme(str(edit.new_value)))
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))
 
         elif section == "skills":
-            result=doc.modify_skill(edit.item_name, edit.new_value)
+            result = _check_result(doc.modify_skill(edit.item_name, edit.new_value))
 
         elif section == "projects":
-            result=doc.modify_project(edit.item_name, edit.field, edit.new_value)
+            result = _check_result(doc.modify_project(edit.item_name, edit.field, edit.new_value))
 
         elif section == "connections":
             if edit.field == "delete":
@@ -490,15 +533,15 @@ def add_project(portfolio_id: str, project_name: str, payload: Optional[ProjectR
     resume_item=project_data.get("resume_item",{}) if isinstance(project_data,dict) else {}
     if not resume_item:
         raise HTTPException(
-            status_code=404,
+            status_code=400,
             detail=f"Project record '{project_name}' has no resume_item data",
         )
 
     proj= Project(
         name=payload.name if payload and payload.name else resume_item.get("project_name",""),
-        start_date=payload.start_date if payload and payload.start_date else "2025-01",
-        end_date=payload.end_date if payload and payload.end_date else "2026-02",
-        location=payload.location if payload and payload.location else "N/A",
+        start_date=payload.start_date if payload and payload.start_date else resume_item.get("start_date", "2025-01"),
+        end_date=payload.end_date if payload and payload.end_date else resume_item.get("end_date", "2026-02"),
+        location=payload.location if payload and payload.location else resume_item.get("location", "N/A"),
         summary=payload.summary if payload and payload.summary else resume_item.get("summary"),
         highlights=payload.highlights if payload and payload.highlights else resume_item.get("highlights"),
     )
@@ -618,6 +661,61 @@ def export_portfolio_custom(portfolio_id: str, format: str, payload: SaveRequest
     return {"status": "Saved successfully", "path": str(dest)}
 
 
+@portfolioRouter.post("/portfolio/{portfolio_id}/add/project/{project_name}/ai")
+def add_project_ai(portfolio_id: str, project_name: str):
+    """Add a project entry to a portfolio using AI-generated content.
+
+    Fetches the project from the database, generates a polished entry
+    using Gemini AI, and adds it to the portfolio document.
+
+    Args:
+        portfolio_id: The portfolio identifier.
+        project_name: The name of the analysed project in the database.
+
+    Returns:
+        dict: {"status": str} confirming the project was added.
+
+    Raises:
+        HTTPException: 404 if the portfolio or project does not exist.
+        HTTPException: 400 if AI generation returned no data.
+        HTTPException: 500 if AI generation or save failed.
+    """
+    doc = _load_portfolio(portfolio_id)
+
+    db_name = project_name
+    if not runtimeAppContext.store.project_exists(db_name) and not project_name.endswith(".json"):
+        db_name = f"{project_name}.json"
+
+    generator = GenerateResumeAI_Ver2(db_name)
+    if not generator.project_exists:
+        raise HTTPException(status_code=404, detail=f"Project '{project_name}' not found in database")
+
+    try:
+        ai_entry = generator.generate_AI_Resume_entry()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"AI generation failed: {e}")
+
+    if ai_entry is None:
+        raise HTTPException(status_code=400, detail=f"AI generation returned no data for '{project_name}'")
+
+    summary = ai_entry.one_sentence_summary
+    if ai_entry.tech_stack:
+        summary = f"{summary} Tech stack: {ai_entry.tech_stack}"
+
+    proj = Project(
+        name=ai_entry.project_title,
+        summary=summary,
+        highlights=ai_entry.key_responsibilities,
+    )
+    try:
+        result = _check_result(doc.add_project(proj))
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to add project: {e}")
+    return {"status": result}
+
+
 @portfolioRouter.delete("/portfolio/{portfolio_id}/project/{project_name}")
 def remove_project(portfolio_id: str, project_name: str):
     """Remove a project entry from an existing portfolio by project name.
@@ -642,7 +740,7 @@ def remove_project(portfolio_id: str, project_name: str):
 
 
 @portfolioRouter.post("/portfolio/{portfolio_id}/add/skill")
-def add_skill(portfolio_id: str, payload:skillRequest):
+def add_skill(portfolio_id: str, payload: SkillRequest):
     """Add a new skill category entry to an existing portfolio.
 
         Args:

--- a/src/API/Resume_Generator_API.py
+++ b/src/API/Resume_Generator_API.py
@@ -26,6 +26,9 @@ Endpoints:
     DELETE /resume/{id}                              - Delete the resume YAML file entirely
 """
 
+import re
+import pendulum
+import ruamel.yaml as _yaml
 from typing import Optional, List, Any
 from pathlib import Path
 import uuid
@@ -42,6 +45,7 @@ from src.reporting.Generate_AI_RenderCV_Portfolio_and_Resume import (
     Connections,
 )
 from src.core.app_context import runtimeAppContext
+from src.reporting.Generate_Resume_AI_Ver2 import GenerateResumeAI_Ver2
 
 RENDERED_OUTPUTS_DIR = Path(__file__).resolve().parents[2] / "User_config_files" / "Generate_render_CV_files" / "rendered_outputs"
 
@@ -49,6 +53,7 @@ RENDERED_OUTPUTS_DIR = Path(__file__).resolve().parents[2] / "User_config_files"
 resumeRouter = APIRouter(tags=["Resume"])
 
 ALLOWED_CONTACT_FIELDS = {"email", "phone", "location", "website", "name"}
+SKIPPING_GENERATION = "Skipping generation"
 
 
 class GenerateResumeRequest(BaseModel):
@@ -248,6 +253,30 @@ def _check_result(result: str):
     return result
 
 
+@resumeRouter.get("/resumes")
+def list_resumes():
+    """List all saved resume IDs, display names, and creation dates.
+
+    Returns:
+        list[dict]: Each entry has 'id', 'name', and 'created_at' (ISO string or None).
+    """
+    cv_dir = Path(__file__).resolve().parents[2] / "User_config_files" / "Generate_render_CV_files"
+    results = []
+    y = _yaml.YAML()
+    for yaml_file in sorted(cv_dir.glob("*_Resume_CV.yaml")):
+        resume_id = yaml_file.stem.replace("_Resume_CV", "")
+        display_name = re.sub(r'_[0-9a-f]{8}$', '', resume_id).replace("_", " ")
+        created_at = None
+        try:
+            with open(yaml_file, "r") as f:
+                data = y.load(f)
+            created_at = data.get("created_at")
+        except Exception:
+            pass
+        results.append({"id": resume_id, "name": display_name, "created_at": created_at})
+    return results
+
+
 @resumeRouter.post("/resume/generate")
 def generate_resume(payload: GenerateResumeRequest):
     """Create a new resume YAML from a starter template.
@@ -268,11 +297,11 @@ def generate_resume(payload: GenerateResumeRequest):
     """
     doc = RenderCVDocument(doc_type="resume")
     resume_id = str(uuid.uuid4())[:8]
-    full_name = f"{payload.name}_{resume_id}"
+    full_name = f"{payload.name.replace(' ', '_')}_{resume_id}"
 
     gen_result = doc.generate(name=full_name, overwrite=payload.overwrite)
 
-    if gen_result == "Skipping generation":
+    if gen_result == SKIPPING_GENERATION:
         raise HTTPException(status_code=409,
                             detail=f"Resume '{payload.name}' already exists. Set overwrite=true to replace it.",
                             )
@@ -284,6 +313,13 @@ def generate_resume(payload: GenerateResumeRequest):
             doc.update_theme(payload.theme)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
+
+    doc.data["created_at"] = pendulum.now("UTC").to_iso8601_string()
+    try:
+        with open(doc.yaml_file, "w") as f:
+            doc.yaml.dump(doc.data, f)
+    except OSError as e:
+        raise HTTPException(status_code=500, detail=f"Resume generated but failed to save metadata: {e}")
 
     return {"resume_id": full_name, "status": "Resume created successfully"}
 
@@ -364,7 +400,7 @@ def edit_resume(id: str, payload: EditResumeRequest):
     Section-specific notes:
         - summary: Only `new_value` is used; `item_name` and `field` are ignored.
         - contact: Use `field` to specify which contact field to update (e.g., email, phone).
-        - theme: Only `new_value` is used; valid themes are 'sb2nov', 'classic', 'moderncv', 'engineeringresumes'.
+        - theme: Only `new_value` is used; valid themes are 'sb2nov', 'classic', 'moderncv', 'engineeringresumes', 'engineeringclassic'.
         - skills: Use `item_name` to identify the skill to rename; `new_value` is the new skill name.
         - experience: Use `item_name` for the job title, `field` for the attribute to change.
         - education: Use `item_name` for the degree name, `field` for the attribute to change.
@@ -629,6 +665,61 @@ def add_project(id: str, project_name: str, payload: Optional[ProjectRequest] = 
     return {"status": result}
 
 
+@resumeRouter.post("/resume/{id}/add/project/{project_name}/ai")
+def add_project_ai(id: str, project_name: str):
+    """Add a project entry to a resume using AI-generated content.
+
+    Fetches the project from the database, generates a polished resume entry
+    using Gemini AI, and adds it to the resume document.
+
+    Args:
+        id: The resume identifier.
+        project_name: The name of the analysed project in the database.
+
+    Returns:
+        dict: {"status": str} confirming the project was added.
+
+    Raises:
+        HTTPException: 404 if the resume or project does not exist.
+        HTTPException: 400 if AI generation returned no data.
+        HTTPException: 500 if AI generation or save failed.
+    """
+    doc = _load_resume(id)
+
+    db_name = project_name
+    if not runtimeAppContext.store.project_exists(db_name) and not project_name.endswith(".json"):
+        db_name = f"{project_name}.json"
+
+    generator = GenerateResumeAI_Ver2(db_name)
+    if not generator.project_exists:
+        raise HTTPException(status_code=404, detail=f"Project '{project_name}' not found in database")
+
+    try:
+        ai_entry = generator.generate_AI_Resume_entry()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"AI generation failed: {e}")
+
+    if ai_entry is None:
+        raise HTTPException(status_code=400, detail=f"AI generation returned no data for '{project_name}'")
+
+    summary = ai_entry.one_sentence_summary
+    if ai_entry.tech_stack:
+        summary = f"{summary} Tech stack: {ai_entry.tech_stack}"
+
+    proj = Project(
+        name=ai_entry.project_title,
+        summary=summary,
+        highlights=ai_entry.key_responsibilities,
+    )
+    try:
+        result = _check_result(doc.add_project(proj))
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to add project: {e}")
+    return {"status": result}
+
+
 @resumeRouter.delete("/resume/{id}/project/{project_name}")
 def remove_project(id: str, project_name: str):
     """Remove a project entry from an existing resume by project name.
@@ -731,6 +822,8 @@ def add_experience(id: str, payload: ExperienceRequest):
         highlights=payload.highlights,
     )
     result = doc.add_experience(exp)
+    if "Duplicate" in result:
+        raise HTTPException(status_code=409, detail=result)
     if result != "Successfully added experience":
         raise HTTPException(status_code=400, detail=result)
     return {"status": result}


### PR DESCRIPTION
## 📝 Description

Add /portfolios and /resumes list endpoints that read created_at from YAML files, and new POST routes to add AI-generated projects to a resume or portfolio. Also includes several validation and error-handling fixes:

- Sanitize document names (replace spaces with underscores)
- Write created_at timestamp using pendulum on new documents
- Normalize HTTPException formatting across endpoints
- Fix duplicate experience returning 409
- Fix contact allowlist handling in portfolio
- Add date validation checks when writing date fields
- Add missing docstrings

> Split out from #501 as requested by reviewer(@Puneet-Maan ).

**Closes:** #501

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

⚠️ Automated tests for this PR are in #524. Merge this PR first, then run:                                                                                                                                                   
   ```bash           
  pytest test/test_resume_generator_API.py                                                                                                                                                                                     
   pytest test/test_portfolio_generator_API.py
   ```

- [ ] GET /resumes and GET /portfolios return list of saved documents with created_at
- [ ] POST AI project endpoint adds project to resume/portfolio correctly
- [ ] Duplicate experience entry returns 409
- [ ] Invalid date fields are rejected with appropriate error
- [ ] Document names with spaces are saved with underscores

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<details>
<summary>Click to expand screenshots</summary>

</details>