### PR TITLE
Clarify activity heatmap counts on dashboard

### DIFF
--- a/frontend/app/dashboard/page.js
+++ b/frontend/app/dashboard/page.js
@@ -190,7 +190,7 @@ function ActivityHeatmap({ projects }) {
           <tr>
             <th>Activity</th>
             {matrix.months.map((m) => (
-              <th key={m}>{m}</th>
+              <th key={m}>{m} (count)</th>
             ))}
           </tr>
         </thead>
@@ -282,7 +282,7 @@ export default function DashboardPage() {
               <GlassCard title="Skills Timeline" hint="Project-level skill count progression.">
                 <TimelineBars projects={projects} />
               </GlassCard>
-              <GlassCard title="Activity Heatmap" hint="Code, test, design, document, and other buckets.">
+              <GlassCard title="Activity Heatmap" hint="Code, test, design, document, and other buckets. Values are counts of detected artifacts for the selected month.">
                 <ActivityHeatmap projects={projects} />
               </GlassCard>
             </div>


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

Clarified the Activity Heatmap values on the dashboard so users can understand what the numbers in the table represent.

This change:
- updates the heatmap card description to explain that the values are counts of detected artifacts for the selected month
- updates each month column header to include `(count)`

This addresses peer review feedback that the numeric values in the heatmap table were unclear.

**Closes:** #584

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Manually tested the dashboard heatmap copy update.

---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [ ] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> 

<details>
<summary>Click to expand screenshots</summary>

<img width="594" height="319" alt="Screenshot 2026-03-21 at 5 02 34 PM" src="https://github.com/user-attachments/assets/58a09332-8414-427a-b99e-3eff15b179e2" />


</details>
