### PR TITLE
made consent form viewable and fixed controls to include consent status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
+
+# Playwright last-run
+.last-run.json

--- a/frontend/app/config/ConsentDocument.js
+++ b/frontend/app/config/ConsentDocument.js
@@ -1,0 +1,58 @@
+/**
+ * Renders the static consent agreement document as structured JSX.
+ *
+ * @returns {JSX.Element}
+ */
+export default function ConsentDocument() {
+  return (
+    <div className="consent-document">
+      <p>This software analyzes data you provide to generate insights about your project. Before continuing, please review the following terms and conditions.</p>
+
+      <h2>How Your Data Will Be Used</h2>
+      <p>Your data will be:</p>
+      <ul>
+        <li>Loaded and processed <strong>locally</strong> on your machine</li>
+        <li>Used to perform analysis and generate results</li>
+        <li>Stored only on your system unless you manually export or share it</li>
+      </ul>
+      <blockquote>You must consent to local data use to run the program.</blockquote>
+
+      <h2>Optional External Processing</h2>
+      <p>
+        The program can optionally send portions of your data to trusted external AI services
+        (e.g., large language model APIs) to enhance analysis quality.
+      </p>
+      <p>If you choose <strong>Do not allow</strong> for external processing:</p>
+      <ul>
+        <li>Your data <strong>stays local</strong></li>
+        <li>The system still runs with <strong>basic analysis only</strong></li>
+      </ul>
+
+      <h2>What We Do NOT Do</h2>
+      <p>We do <strong>not</strong>:</p>
+      <ul>
+        <li>Collect personal information outside the data you provide</li>
+        <li>Sell or share your data</li>
+        <li>Store your data remotely</li>
+      </ul>
+
+      <h2>Revoking Consent</h2>
+      <p>You can revoke consent at any time. When revoked:</p>
+      <ul>
+        <li>Local processing stops</li>
+        <li>External processing (if enabled) stops</li>
+        <li>You may delete any local project files or outputs</li>
+      </ul>
+
+      <p className="muted" style={{ marginTop: "1rem", fontSize: "0.82rem" }}>
+        By saving your configuration below, you acknowledge that you understand and agree to local
+        data processing. External processing is optional and controlled by the consent toggle.
+        You may change or revoke your choices at any time by returning to this page.
+      </p>
+
+      <p className="muted" style={{ fontSize: "0.78rem" }}>
+        Team 2 · COSC 499 Capstone · 2025/26 · University of British Columbia
+      </p>
+    </div>
+  );
+}

--- a/frontend/app/config/helpers.js
+++ b/frontend/app/config/helpers.js
@@ -1,21 +1,27 @@
 export function resolveExternalConsentState(config) {
   const external = config?.consented?.external;
   if (external === true) return "allow";
-  if (external === false) return "deny";
-  return "unset";
+  return "deny";
 }
 
 export function formatExternalConsentLabel(state) {
   if (state === "allow") return "Allow";
-  if (state === "deny") return "Do not allow";
-  return "Not set";
+  return "Do not allow";
 }
 
-export function validateExternalConsentSelection(state) {
-  if (state === "unset") {
-    return "Please choose whether external tools are allowed.";
-  }
+export function validateExternalConsentSelection(_state) {
   return "";
+}
+
+export function resolveLocalConsentState(config) {
+  const local = config?.consented?.["Data consent"];
+  if (local === true) return "allow";
+  return "deny";
+}
+
+export function formatLocalConsentLabel(state) {
+  if (state === "allow") return "Allow";
+  return "Do not allow";
 }
 
 export function applyNameToConfig(baseConfig, fullName) {

--- a/frontend/app/config/page.js
+++ b/frontend/app/config/page.js
@@ -16,8 +16,7 @@ import {
   formatExternalConsentLabel,
   formatLocalConsentLabel,
   resolveExternalConsentState,
-  resolveLocalConsentState,
-  validateExternalConsentSelection
+  resolveLocalConsentState
 } from "./helpers";
 import ConsentDocument from "./ConsentDocument";
 
@@ -31,6 +30,7 @@ export default function ConfigPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [message, setMessage] = useState("");
+  const [consentWarning, setConsentWarning] = useState("");
 
   const [externalConsent, setExternalConsent] = useState("deny");
   const [localConsent, setLocalConsent] = useState("deny");
@@ -80,20 +80,21 @@ export default function ConfigPage() {
 
     setError("");
     setMessage("");
+    setConsentWarning("");
 
-    const consentError = validateExternalConsentSelection(externalConsent);
-    if (consentError) {
-      setError(consentError);
-      return;
+    const allowLocal = localConsent === "allow";
+    const effectiveExternal = externalConsent === "allow" && allowLocal;
+
+    if (!allowLocal && externalConsent === "allow") {
+      setExternalConsent("deny");
+      setConsentWarning("External tools consent requires local data processing to be allowed. External consent has been turned off.");
     }
 
     try {
-      const allowExternal = externalConsent === "allow";
-      const allowLocal = localConsent === "allow";
-      await saveConsent(allowExternal);
+      await saveConsent(effectiveExternal, allowLocal);
 
       const nextConfig = applyNameToConfig(config, fullName);
-      nextConfig.consented = { external: allowExternal, "Data consent": allowLocal };
+      nextConfig.consented = { external: effectiveExternal, "Data consent": allowLocal };
 
       await updateConfig(nextConfig);
       setConfig(nextConfig);
@@ -103,6 +104,10 @@ export default function ConfigPage() {
       setError(err.message || "Failed to save configuration.");
     }
   }
+
+  const savedName = config
+    ? [String(config["First Name"] || ""), String(config["Last Name"] || "")].filter(Boolean).join(" ")
+    : "";
 
   const currentExternalConsent = formatExternalConsentLabel(resolveExternalConsentState(config));
   const currentLocalConsent = formatLocalConsentLabel(resolveLocalConsentState(config));
@@ -115,6 +120,7 @@ export default function ConfigPage() {
       <div className="page-stack config-page">
         {loading ? <p className="muted">Loading configuration...</p> : null}
         {error ? <p className="error">{error}</p> : null}
+        {consentWarning ? <p className="consent-deny-warning">{consentWarning}</p> : null}
         {message ? <p className="success">{message}</p> : null}
 
         {!loading && config ? (
@@ -197,8 +203,8 @@ export default function ConfigPage() {
               </form>
             </GlassCard>
 
-            <GlassCard title="Current Settings">
-              <p className="muted">Current persisted configuration values.</p>
+            <GlassCard title="Saved Settings">
+              <p className="muted">Last persisted configuration values.</p>
               <div className="settings-list">
                 <div className={`settings-row ${currentLocalConsent === "Allow" ? "status-ok" : "status-missing"}`.trim()}>
                   <span className="settings-label">Local processing</span>
@@ -208,9 +214,9 @@ export default function ConfigPage() {
                   <span className="settings-label">External tools</span>
                   <strong className="settings-value">{currentExternalConsent}</strong>
                 </div>
-                <div className={`settings-row ${fullName ? "status-ok" : "status-missing"}`.trim()}>
+                <div className={`settings-row ${savedName ? "status-ok" : "status-missing"}`.trim()}>
                   <span className="settings-label">Name</span>
-                  <strong className="settings-value">{fullName || "Not set"}</strong>
+                  <strong className="settings-value">{savedName || "Not set"}</strong>
                 </div>
               </div>
             </GlassCard>

--- a/frontend/app/config/page.js
+++ b/frontend/app/config/page.js
@@ -14,9 +14,12 @@ import { fetchConfig, saveConsent, updateConfig } from "../../lib/api";
 import {
   applyNameToConfig,
   formatExternalConsentLabel,
+  formatLocalConsentLabel,
   resolveExternalConsentState,
+  resolveLocalConsentState,
   validateExternalConsentSelection
 } from "./helpers";
+import ConsentDocument from "./ConsentDocument";
 
 /**
  * User configuration route for consent and profile settings.
@@ -29,8 +32,10 @@ export default function ConfigPage() {
   const [error, setError] = useState("");
   const [message, setMessage] = useState("");
 
-  const [externalConsent, setExternalConsent] = useState("unset");
+  const [externalConsent, setExternalConsent] = useState("deny");
+  const [localConsent, setLocalConsent] = useState("deny");
   const [fullName, setFullName] = useState("");
+  const [consentExpanded, setConsentExpanded] = useState(false);
 
   useEffect(() => {
     let ignore = false;
@@ -42,8 +47,9 @@ export default function ConfigPage() {
         const data = await fetchConfig();
         if (ignore) return;
         setConfig(data || {});
-
+        setConsentExpanded(!data?.consented?.["Data consent"]);
         setExternalConsent(resolveExternalConsentState(data));
+        setLocalConsent(resolveLocalConsentState(data));
 
         const first = String(data?.["First Name"] || "").trim();
         const last = String(data?.["Last Name"] || "").trim();
@@ -83,13 +89,15 @@ export default function ConfigPage() {
 
     try {
       const allowExternal = externalConsent === "allow";
+      const allowLocal = localConsent === "allow";
       await saveConsent(allowExternal);
 
       const nextConfig = applyNameToConfig(config, fullName);
-      nextConfig.consented = { external: allowExternal, "Data consent": true };
+      nextConfig.consented = { external: allowExternal, "Data consent": allowLocal };
 
       await updateConfig(nextConfig);
       setConfig(nextConfig);
+      window.dispatchEvent(new CustomEvent("consentUpdated"));
       setMessage("Configuration saved.");
     } catch (err) {
       setError(err.message || "Failed to save configuration.");
@@ -97,6 +105,7 @@ export default function ConfigPage() {
   }
 
   const currentExternalConsent = formatExternalConsentLabel(resolveExternalConsentState(config));
+  const currentLocalConsent = formatLocalConsentLabel(resolveLocalConsentState(config));
 
   return (
     <LiquidShell
@@ -109,24 +118,50 @@ export default function ConfigPage() {
         {message ? <p className="success">{message}</p> : null}
 
         {!loading && config ? (
-          <div className="grid two-col config-grid">
-            <GlassCard title="Current Settings">
-              <p className="muted">Current persisted configuration values.</p>
-              <div className="settings-list">
-                <div className={`settings-row ${currentExternalConsent === "Not set" ? "status-missing" : "status-ok"}`.trim()}>
-                  <span className="settings-label">External tools</span>
-                  <strong className="settings-value">{currentExternalConsent}</strong>
+          <GlassCard title="Data Consent Agreement">
+            {consentExpanded ? (
+              <>
+                <ConsentDocument />
+                <div className="button-row" style={{ marginTop: "0.75rem" }}>
+                  <button type="button" className="liquid-btn" onClick={() => setConsentExpanded(false)}>
+                    Collapse ▲
+                  </button>
                 </div>
-                <div className={`settings-row ${fullName ? "status-ok" : "status-missing"}`.trim()}>
-                  <span className="settings-label">Name</span>
-                  <strong className="settings-value">{fullName || "Not set"}</strong>
-                </div>
+              </>
+            ) : (
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+                <p className="muted" style={{ margin: 0 }}>You have previously reviewed and agreed to the consent agreement.</p>
+                <button type="button" className="liquid-btn" onClick={() => setConsentExpanded(true)}>
+                  View agreement ▼
+                </button>
               </div>
-            </GlassCard>
+            )}
+          </GlassCard>
+        ) : null}
 
+        {!loading && config ? (
+          <div className="grid two-col config-grid">
             <GlassCard title="Update Settings">
               <p className="muted">Adjust values and save to persist changes.</p>
               <form onSubmit={onSave} className="form-stack config-form">
+                <label>
+                  Local data processing consent
+                  <LiquidSegmentedControl
+                    className="config-consent-control"
+                    value={localConsent}
+                    onChange={setLocalConsent}
+                    options={[
+                      { value: "allow", label: "Allow" },
+                      { value: "deny", label: "Do not allow" }
+                    ]}
+                  />
+                </label>
+                {localConsent === "deny" ? (
+                  <p className="consent-deny-warning">
+                    ⚠ Local consent must be allowed to use this software.
+                  </p>
+                ) : null}
+
                 <label>
                   External tools consent
                   <LiquidSegmentedControl
@@ -134,12 +169,16 @@ export default function ConfigPage() {
                     value={externalConsent}
                     onChange={setExternalConsent}
                     options={[
-                      { value: "unset", label: "Not set" },
                       { value: "allow", label: "Allow" },
                       { value: "deny", label: "Do not allow" }
                     ]}
                   />
                 </label>
+                {externalConsent === "deny" ? (
+                  <p className="consent-deny-warning">
+                    ⚠ External tools are disabled. AI-powered features will not be available.
+                  </p>
+                ) : null}
 
                 <label className="settings-row settings-field-row">
                   <span className="settings-label">Full name</span>
@@ -156,6 +195,24 @@ export default function ConfigPage() {
                   <button type="submit" className="liquid-btn solid">Save Configuration</button>
                 </div>
               </form>
+            </GlassCard>
+
+            <GlassCard title="Current Settings">
+              <p className="muted">Current persisted configuration values.</p>
+              <div className="settings-list">
+                <div className={`settings-row ${currentLocalConsent === "Allow" ? "status-ok" : "status-missing"}`.trim()}>
+                  <span className="settings-label">Local processing</span>
+                  <strong className="settings-value">{currentLocalConsent}</strong>
+                </div>
+                <div className={`settings-row ${currentExternalConsent === "Allow" ? "status-ok" : "status-missing"}`.trim()}>
+                  <span className="settings-label">External tools</span>
+                  <strong className="settings-value">{currentExternalConsent}</strong>
+                </div>
+                <div className={`settings-row ${fullName ? "status-ok" : "status-missing"}`.trim()}>
+                  <span className="settings-label">Name</span>
+                  <strong className="settings-value">{fullName || "Not set"}</strong>
+                </div>
+              </div>
             </GlassCard>
           </div>
         ) : null}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2101,6 +2101,53 @@ textarea::placeholder {
   margin-top: 0.72rem;
 }
 
+.consent-deny-warning {
+  color: #c0392b;
+  background: rgba(192, 57, 43, 0.08);
+  border: 1px solid rgba(192, 57, 43, 0.45);
+  border-radius: var(--control-radius);
+  padding: 0.4rem 0.7rem;
+  font-size: 0.83rem;
+  font-weight: 500;
+  margin-top: 0.4rem;
+}
+
+.consent-document {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--ink-0);
+}
+
+.consent-document h2 {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin-top: 1.1rem;
+  margin-bottom: 0.3rem;
+  color: var(--ink-0);
+}
+
+.consent-document ul {
+  padding-left: 1.4rem;
+  margin: 0.3rem 0;
+}
+
+.consent-document li {
+  margin-bottom: 0.2rem;
+}
+
+.consent-document blockquote {
+  border-left: 3px solid var(--success, #27ae60);
+  margin: 0.75rem 0;
+  padding: 0.4rem 0.8rem;
+  background: color-mix(in srgb, var(--success, #27ae60) 8%, transparent);
+  border-radius: 0 4px 4px 0;
+  font-weight: 500;
+}
+
+.consent-document p {
+  margin: 0.4rem 0;
+}
+
 .workspace-page {
   --controls-field-w: 260px;
 }

--- a/frontend/app/workspace/page.js
+++ b/frontend/app/workspace/page.js
@@ -655,8 +655,7 @@ function ProjectEditor({ projects, docProjects, onAddProject, onAddProjectAI, on
             <button type="button" className="liquid-btn solid btn-success" disabled={busy || aiLoading} onClick={() => onAddProject(projectName, payload)}>
               Add Project
             </button>
-            <button type="button" className="liquid-btn solid btn-success" disabled={busy || aiLoading || !externalAllowed} onClick={async () => { setAiLoading(true); try { await onAddProjectAI(projectName); } finally { setAiLoading(false); } }} title="Use Gemini AI to generate a polished project entry">
-            <button type="button" className="liquid-btn solid btn-success" disabled={busy || aiLoading} onClick={async () => { setAiLoading(true); try { await onAddProjectAI(projectName, { start_date: toMonthValue(startDate) || undefined, end_date: toMonthValue(endDate) || undefined }); } finally { setAiLoading(false); } }} title="Use Gemini AI to generate a polished project entry">
+            <button type="button" className="liquid-btn solid btn-success" disabled={busy || aiLoading || !externalAllowed} onClick={async () => { setAiLoading(true); try { await onAddProjectAI(projectName, { start_date: toMonthValue(startDate) || undefined, end_date: toMonthValue(endDate) || undefined }); } finally { setAiLoading(false); } }} title="Use Gemini AI to generate a polished project entry">
               {aiLoading ? "⏳ Generating..." : "✦ Add with AI"}
             </button>
           </div>

--- a/frontend/app/workspace/page.js
+++ b/frontend/app/workspace/page.js
@@ -44,7 +44,8 @@ import {
   removeResumeSkill,
   addPortfolioSkill,
   appendPortfolioSkill,
-  removePortfolioSkill
+  removePortfolioSkill,
+  fetchConfig
 } from "../../lib/api";
 
 /**
@@ -538,7 +539,7 @@ function PortfolioRoleOverrideCard({ title, projectName, hint = "" }) {
  * }} props
  * @returns {JSX.Element}
  */
-function ProjectEditor({ projects, docProjects, onAddProject, onAddProjectAI, onEditProject, onRemoveProject, busy = false, allowRoleOverride = false }) {
+function ProjectEditor({ projects, docProjects, onAddProject, onAddProjectAI, onEditProject, onRemoveProject, busy = false, allowRoleOverride = false, externalAllowed = false }) {
   const [aiLoading, setAiLoading] = useState(false);
   const [projectName, setProjectName] = useState(projects[0] || "");
   const [summary, setSummary] = useState("");
@@ -611,7 +612,7 @@ function ProjectEditor({ projects, docProjects, onAddProject, onAddProjectAI, on
             <button type="button" className="liquid-btn solid btn-success" disabled={busy || aiLoading} onClick={() => onAddProject(projectName, payload)}>
               Add Project
             </button>
-            <button type="button" className="liquid-btn solid btn-success" disabled={busy || aiLoading} onClick={async () => { setAiLoading(true); try { await onAddProjectAI(projectName); } finally { setAiLoading(false); } }} title="Use Gemini AI to generate a polished project entry">
+            <button type="button" className="liquid-btn solid btn-success" disabled={busy || aiLoading || !externalAllowed} onClick={async () => { setAiLoading(true); try { await onAddProjectAI(projectName); } finally { setAiLoading(false); } }} title="Use Gemini AI to generate a polished project entry">
               {aiLoading ? "⏳ Generating..." : "✦ Add with AI"}
             </button>
           </div>
@@ -1129,6 +1130,13 @@ function DocumentStudio({ kind, mode }) {
   const [editCategory, setEditCategory] = useState("contact");
   const [savedProjects, setSavedProjects] = useState([]);
   const [savedDocs, setSavedDocs] = useState([]);
+  const [externalAllowed, setExternalAllowed] = useState(false);
+
+  useEffect(() => {
+    fetchConfig()
+      .then((cfg) => setExternalAllowed(cfg?.consented?.external === true))
+      .catch(() => {});
+  }, []);
 
   const [activeRenderActions, setActiveRenderActions] = useState([]);
   const activeRenderActionsRef = useRef(new Set());
@@ -1255,6 +1263,50 @@ function DocumentStudio({ kind, mode }) {
         // non-critical — status card will show "—" if list fetch fails
       }
     }, `${isResume ? "Resume" : "Portfolio"} created.`);
+  }
+
+  /**
+   * Creates a new document and adds all saved projects using AI enhancement.
+   *
+   * @returns {Promise<void>}
+   */
+  async function onGenerateAI() {
+    if (!name.trim()) {
+      setError("Name is required.");
+      return;
+    }
+    if (!theme) {
+      setError("Theme is required.");
+      return;
+    }
+
+    await safeAction(async () => {
+      const res = isResume ? await generateResume(name.trim(), theme) : await generatePortfolio(name.trim(), theme);
+      const id = isResume ? res.resume_id : res.portfolio_id;
+      setDocId(id);
+      setIdInput(id);
+
+      for (const projectName of savedProjects) {
+        try {
+          if (isResume) await addResumeProjectAI(id, projectName);
+          else await addPortfolioProjectAI(id, projectName);
+        } catch {
+          // individual project failures are non-fatal
+        }
+      }
+
+      const data = isResume ? await fetchResume(id) : await fetchPortfolio(id);
+      setDoc(data);
+      const merged = [id, ...readRecentIds().filter((x) => x !== id)].slice(0, 10);
+      saveRecentIds(merged);
+      const listFn = isResume ? fetchResumes : fetchPortfolios;
+      try {
+        const docs = await listFn();
+        setSavedDocs(Array.isArray(docs) ? docs : []);
+      } catch {
+        // non-critical
+      }
+    }, `${isResume ? "Resume" : "Portfolio"} created with AI.`);
   }
 
   /**
@@ -1556,6 +1608,9 @@ function DocumentStudio({ kind, mode }) {
               <button type="button" className="liquid-btn solid btn-success" disabled={busy || !theme} onClick={onGenerate}>
                 Generate {isResume ? "Resume" : "Portfolio"}
               </button>
+              <button type="button" className="liquid-btn solid btn-success" disabled={busy || !theme || !externalAllowed} onClick={onGenerateAI}>
+                Generate {isResume ? "Resume" : "Portfolio"} with AI
+              </button>
             </div>
 
             <div className="settings-list compact">
@@ -1695,6 +1750,7 @@ function DocumentStudio({ kind, mode }) {
               onEditProject={(projectName, field, value) => onApplyEdits([{ section: "projects", item_name: projectName, field, new_value: value }])}
               onRemoveProject={onRemoveProject}
               allowRoleOverride={!isResume}
+              externalAllowed={externalAllowed}
               busy={busy}
             />
           ) : null}

--- a/frontend/components/LiquidShell.jsx
+++ b/frontend/components/LiquidShell.jsx
@@ -72,6 +72,8 @@ export function LiquidShell({ title, subtitle, children, rightSlot }) {
   const [flowError, setFlowError] = useState("");
   const [consentReady, setConsentReady] = useState(false);
   const [projectsReady, setProjectsReady] = useState(false);
+  const fetchingRef = useRef(true);
+  const [consentVersion, setConsentVersion] = useState(0);
 
   useEffect(() => {
     /**
@@ -178,6 +180,7 @@ export function LiquidShell({ title, subtitle, children, rightSlot }) {
 
   useEffect(() => {
     let ignore = false;
+    fetchingRef.current = true;
     async function loadFlowReadiness() {
       setFlowLoading(true);
       setFlowError("");
@@ -195,7 +198,10 @@ export function LiquidShell({ title, subtitle, children, rightSlot }) {
           setFlowError("Some prerequisite checks could not be loaded. Backend may be offline.");
         }
       } finally {
-        if (!ignore) setFlowLoading(false);
+        if (!ignore) {
+          fetchingRef.current = false;
+          setFlowLoading(false);
+        }
       }
     }
 
@@ -203,10 +209,18 @@ export function LiquidShell({ title, subtitle, children, rightSlot }) {
     return () => {
       ignore = true;
     };
+  }, [pathname, consentVersion]);
+
+  useEffect(() => {
+    function onConsentUpdated() {
+      setConsentVersion((v) => v + 1);
+    }
+    window.addEventListener("consentUpdated", onConsentUpdated);
+    return () => window.removeEventListener("consentUpdated", onConsentUpdated);
   }, []);
 
   useEffect(() => {
-    if (flowLoading || flowError) return;
+    if (fetchingRef.current || flowLoading || flowError) return;
     const currentRoute = [...links, ...flowSteps].find((route) => route.href === pathname);
     if (currentRoute && !isRouteUnlocked(currentRoute, consentReady, projectsReady)) {
       if (!consentReady) {

--- a/frontend/components/LiquidShell.jsx
+++ b/frontend/components/LiquidShell.jsx
@@ -226,7 +226,10 @@ export function LiquidShell({ title, subtitle, children, rightSlot }) {
       if (!consentReady) {
         router.replace("/config");
         return;
-      }
+if (!consentReady && pathname !=="/config") {
+    router.replace("/config");
+    return;
+   }
       if (!projectsReady) {
         router.replace("/upload");
       }

--- a/frontend/components/LiquidShell.jsx
+++ b/frontend/components/LiquidShell.jsx
@@ -223,13 +223,10 @@ export function LiquidShell({ title, subtitle, children, rightSlot }) {
     if (fetchingRef.current || flowLoading || flowError) return;
     const currentRoute = [...links, ...flowSteps].find((route) => route.href === pathname);
     if (currentRoute && !isRouteUnlocked(currentRoute, consentReady, projectsReady)) {
-      if (!consentReady) {
+      if (!consentReady && pathname !== "/config") {
         router.replace("/config");
         return;
-if (!consentReady && pathname !=="/config") {
-    router.replace("/config");
-    return;
-   }
+      }
       if (!projectsReady) {
         router.replace("/upload");
       }

--- a/frontend/components/LiquidShell.jsx
+++ b/frontend/components/LiquidShell.jsx
@@ -196,12 +196,12 @@ export function LiquidShell({ title, subtitle, children, rightSlot }) {
 
   useEffect(() => {
     if (fetchingRef.current || flowLoading || flowError) return;
+    if (!consentReady && pathname !== "/config") {
+      router.replace("/config");
+      return;
+    }
     const currentRoute = [...links, ...flowSteps].find((route) => route.href === pathname);
     if (currentRoute && !isRouteUnlocked(currentRoute, consentReady, projectsReady)) {
-      if (!consentReady && pathname !== "/config") {
-        router.replace("/config");
-        return;
-      }
       if (!projectsReady) {
         router.replace("/upload");
       }

--- a/frontend/e2e/milestone3-flows.spec.js
+++ b/frontend/e2e/milestone3-flows.spec.js
@@ -320,7 +320,7 @@ test("generates and loads a portfolio in the workspace", async ({ page }) => {
   await installApiMocks(page);
 
   await page.goto("/workspace");
-  await page.getByRole("button", { name: "P o r t f o l i o", exact: true }).click();
+  await page.getByRole("radio", { name: "P o r t f o l i o", exact: true }).click();
 
   await page.getByLabel("Full name").fill("Jane Doe");
   await page.getByLabel("Theme").selectOption("sb2nov");
@@ -336,7 +336,7 @@ test("dashboard public mode persists and workspace remains authoring", async ({ 
   await page.goto("/dashboard");
   await expect(page.getByRole("heading", { name: /Dashboard/ })).toBeVisible();
 
-  await page.getByRole("button", { name: "P u b l i c", exact: true }).click();
+  await page.getByRole("radio", { name: "P u b l i c", exact: true }).click();
 
   await expect(page.getByLabel("Search")).toBeVisible();
   await expect(page.getByLabel("Type")).toBeVisible();

--- a/frontend/e2e/milestone3-flows.spec.js
+++ b/frontend/e2e/milestone3-flows.spec.js
@@ -201,13 +201,16 @@ test("saves config consent and profile details", async ({ page }) => {
   await page.goto("/config");
 
   await expect(page.getByRole("heading", { name: "User Configuration" })).toBeVisible();
-  await page.getByRole("button", { name: "A l l o w", exact: true }).click();
+  // Scope to the external consent control (second .config-consent-control) to avoid
+  // matching the local consent "Allow" button
+  await page.locator(".config-consent-control").nth(1).locator("button").first().click();
   await page.getByLabel("Full name").fill("Jane Doe");
   await page.getByRole("button", { name: "Save Configuration" }).click();
 
   await expect(page.getByText("Configuration saved.")).toBeVisible();
-  await expect(page.locator(".config-grid .settings-row").nth(0)).toContainText("Allow");
-  await expect(page.locator(".config-grid .settings-row").nth(1)).toContainText("Jane Doe");
+  // nth(0) = full name input row (Update Settings), nth(1) = local, nth(2) = external, nth(3) = name
+  await expect(page.locator(".config-grid .settings-row").nth(2)).toContainText("Allow");
+  await expect(page.locator(".config-grid .settings-row").nth(3)).toContainText("Jane Doe");
 });
 
 test("uploads and analyzes a zip, then shows it on the dashboard", async ({ page }) => {
@@ -237,7 +240,7 @@ test("generates and loads a resume in the workspace", async ({ page }) => {
   await expect(page.getByRole("heading", { name: /Resume \+ Portfolio Builder/ })).toBeVisible();
   await page.getByLabel("Full name").fill("Jane Doe");
   await page.getByLabel("Theme").selectOption("sb2nov");
-  await page.getByRole("button", { name: /Generate Resume/ }).click();
+  await page.getByRole("button", { name: "Generate Resume", exact: true }).click();
 
   await expect(page.getByText("Resume created.")).toBeVisible();
   await expect(page.locator(".workspace-page .settings-row").filter({ hasText: "Active ID" })).toContainText("Jane_Doe_resume_001");
@@ -251,7 +254,7 @@ test("generates and loads a portfolio in the workspace", async ({ page }) => {
 
   await page.getByLabel("Full name").fill("Jane Doe");
   await page.getByLabel("Theme").selectOption("sb2nov");
-  await page.getByRole("button", { name: /Generate Portfolio/ }).click();
+  await page.getByRole("button", { name: "Generate Portfolio", exact: true }).click();
 
   await expect(page.getByText("Portfolio created.")).toBeVisible();
   await expect(page.locator(".workspace-page .settings-row").filter({ hasText: "Active ID" })).toContainText("Jane_Doe_portfolio_001");
@@ -270,4 +273,83 @@ test("public mode toggle persists on upload route", async ({ page }) => {
   await expect(page.locator('a[href="/dashboard"]')).toBeVisible();
   await expect(page.locator('a[href="/workspace"]')).toBeVisible();
   expect(await page.evaluate(() => window.localStorage.getItem("viewMode"))).toBe("public");
+});
+
+test("first-time user with no consent is redirected to config and sees consent document expanded", async ({ page }) => {
+  await installApiMocks(page, {
+    config: { "First Name": "", "Last Name": "" }
+  });
+
+  await page.goto("/dashboard");
+
+  await expect(page).toHaveURL(/\/config$/);
+  await expect(page.getByRole("heading", { name: "Data Consent Agreement" })).toBeVisible();
+  await expect(page.locator(".consent-document")).toBeVisible();
+  await expect(page.getByRole("button", { name: /Collapse/ })).toBeVisible();
+});
+
+test("returning user with consent set sees consent document collapsed", async ({ page }) => {
+  await installApiMocks(page, {
+    config: { consented: { external: true, "Data consent": true }, "First Name": "Jane", "Last Name": "Doe" }
+  });
+
+  await page.goto("/config");
+
+  await expect(page.getByRole("heading", { name: "Data Consent Agreement" })).toBeVisible();
+  await expect(page.locator(".consent-document")).not.toBeVisible();
+  await expect(page.getByRole("button", { name: /View agreement/ })).toBeVisible();
+});
+
+test("local consent deny warning appears when set to do not allow", async ({ page }) => {
+  await installApiMocks(page, {
+    config: { consented: { external: true, "Data consent": true }, "First Name": "", "Last Name": "" }
+  });
+
+  await page.goto("/config");
+
+  // Switch local consent to "Do not allow" — first .config-consent-control, last button
+  await page.locator(".config-consent-control").first().locator("button").last().click();
+
+  await expect(page.locator(".consent-deny-warning").first()).toBeVisible();
+  await expect(page.locator(".consent-deny-warning").first()).toContainText("Local consent must be allowed");
+});
+
+test("external consent deny warning appears when set to do not allow", async ({ page }) => {
+  await installApiMocks(page, {
+    config: { consented: { external: true, "Data consent": true }, "First Name": "", "Last Name": "" }
+  });
+
+  await page.goto("/config");
+
+  // Switch external consent to "Do not allow" — second .config-consent-control, last button
+  await page.locator(".config-consent-control").nth(1).locator("button").last().click();
+
+  await expect(page.locator(".consent-deny-warning").last()).toBeVisible();
+  await expect(page.locator(".consent-deny-warning").last()).toContainText("External tools are disabled");
+});
+
+test("generate with AI button is disabled when external consent is off", async ({ page }) => {
+  await installApiMocks(page, {
+    config: { consented: { external: false, "Data consent": true }, "First Name": "", "Last Name": "" }
+  });
+
+  await page.goto("/workspace");
+
+  await expect(page.getByRole("button", { name: /Generate Resume with AI/ })).toBeDisabled();
+});
+
+test("generate with AI button is enabled when external consent is on", async ({ page }) => {
+  await installApiMocks(page, {
+    config: { consented: { external: true, "Data consent": true }, "First Name": "", "Last Name": "" }
+  });
+
+  await page.goto("/workspace");
+  await expect(page.getByRole("heading", { name: /Resume \+ Portfolio Builder/ })).toBeVisible();
+  // Wait for initial fetches (config, projects, docs) to complete so state is settled
+  // before interacting with the controlled select — avoids a race where setExternalAllowed
+  // re-render overwrites the DOM select value set by selectOption before onChange propagates
+  await page.waitForLoadState("networkidle");
+  await page.getByLabel("Theme").selectOption("sb2nov");
+
+  await expect(page.getByRole("button", { name: /Generate Resume with AI/ })).toBeEnabled();
 });

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -181,11 +181,11 @@ export function fetchConfig() {
  * @param {boolean} externalAllowed Whether external integrations are allowed.
  * @returns {Promise<any>}
  */
-export function saveConsent(externalAllowed) {
+export function saveConsent(externalAllowed, dataAllowed = true) {
   return request("/privacy-consent", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ data_consent: true, external_consent: externalAllowed })
+    body: JSON.stringify({ data_consent: dataAllowed, external_consent: externalAllowed })
   });
 }
 

--- a/frontend/test/config-helpers.test.js
+++ b/frontend/test/config-helpers.test.js
@@ -4,30 +4,41 @@ import assert from "node:assert/strict";
 import {
   applyNameToConfig,
   formatExternalConsentLabel,
+  formatLocalConsentLabel,
   resolveExternalConsentState,
+  resolveLocalConsentState,
   validateExternalConsentSelection
 } from "../app/config/helpers.js";
 
-test("resolveExternalConsentState maps true, false, and missing values explicitly", () => {
+test("resolveExternalConsentState maps true to allow, anything else to deny", () => {
   assert.equal(resolveExternalConsentState({ consented: { external: true } }), "allow");
   assert.equal(resolveExternalConsentState({ consented: { external: false } }), "deny");
-  assert.equal(resolveExternalConsentState({ consented: {} }), "unset");
-  assert.equal(resolveExternalConsentState({}), "unset");
+  assert.equal(resolveExternalConsentState({ consented: {} }), "deny");
+  assert.equal(resolveExternalConsentState({}), "deny");
+  assert.equal(resolveExternalConsentState(null), "deny");
 });
 
 test("formatExternalConsentLabel renders user-facing consent labels", () => {
   assert.equal(formatExternalConsentLabel("allow"), "Allow");
   assert.equal(formatExternalConsentLabel("deny"), "Do not allow");
-  assert.equal(formatExternalConsentLabel("unset"), "Not set");
 });
 
-test("validateExternalConsentSelection requires an explicit consent choice", () => {
-  assert.equal(
-    validateExternalConsentSelection("unset"),
-    "Please choose whether external tools are allowed."
-  );
+test("validateExternalConsentSelection always returns no error", () => {
   assert.equal(validateExternalConsentSelection("allow"), "");
   assert.equal(validateExternalConsentSelection("deny"), "");
+});
+
+test("resolveLocalConsentState maps true to allow, anything else to deny", () => {
+  assert.equal(resolveLocalConsentState({ consented: { "Data consent": true } }), "allow");
+  assert.equal(resolveLocalConsentState({ consented: { "Data consent": false } }), "deny");
+  assert.equal(resolveLocalConsentState({ consented: {} }), "deny");
+  assert.equal(resolveLocalConsentState({}), "deny");
+  assert.equal(resolveLocalConsentState(null), "deny");
+});
+
+test("formatLocalConsentLabel renders user-facing consent labels", () => {
+  assert.equal(formatLocalConsentLabel("allow"), "Allow");
+  assert.equal(formatLocalConsentLabel("deny"), "Do not allow");
 });
 
 test("applyNameToConfig splits a full name into first and last name fields", () => {

--- a/src/API/Portfolio_Generator_API.py
+++ b/src/API/Portfolio_Generator_API.py
@@ -700,6 +700,11 @@ def add_project_ai(portfolio_id: str, project_name: str, overrides: Optional[AIP
         HTTPException: 400 if AI generation returned no data.
         HTTPException: 500 if AI generation or save failed.
     """
+    if not runtimeAppContext.external_consent:
+        raise HTTPException(status_code=403, detail="External consent is required to use AI features.")
+    if not runtimeAppContext.data_consent:
+        raise HTTPException(status_code=403, detail="Data consent is required to use AI features.")
+
     doc = _load_portfolio(portfolio_id)
 
     db_name = project_name

--- a/src/API/Resume_Generator_API.py
+++ b/src/API/Resume_Generator_API.py
@@ -742,6 +742,11 @@ def add_project_ai(id: str, project_name: str, overrides: Optional[AIProjectOver
         HTTPException: 400 if AI generation returned no data.
         HTTPException: 500 if AI generation or save failed.
     """
+    if not runtimeAppContext.external_consent:
+        raise HTTPException(status_code=403, detail="External consent is required to use AI features.")
+    if not runtimeAppContext.data_consent:
+        raise HTTPException(status_code=403, detail="Data consent is required to use AI features.")
+
     doc = _load_resume(id)
 
     db_name = project_name

--- a/test/test_portfolio_generator_API.py
+++ b/test/test_portfolio_generator_API.py
@@ -902,6 +902,20 @@ class TestAddProjectAIWithOverrides(_BasePortfolioTest):
             self.assertIsNone(proj.start_date)
             self.assertIsNone(proj.end_date)
 
+    def test_blocked_when_external_consent_false(self):
+        """Returns 403 when external_consent is False on runtimeAppContext."""
+        self.mock_ctx.external_consent = False
+        self.mock_ctx.data_consent = True
+        resp = self.client.post("/portfolio/test_abc123/add/project/MyProject/ai")
+        self.assertEqual(resp.status_code, 403)
+
+    def test_blocked_when_data_consent_false(self):
+        """Returns 403 when data_consent is False on runtimeAppContext."""
+        self.mock_ctx.external_consent = True
+        self.mock_ctx.data_consent = False
+        resp = self.client.post("/portfolio/test_abc123/add/project/MyProject/ai")
+        self.assertEqual(resp.status_code, 403)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_resume_generator_API.py
+++ b/test/test_resume_generator_API.py
@@ -1060,6 +1060,20 @@ class TestAddProjectAIWithOverrides(_BaseResumeTest):
             self.assertIsNone(proj.start_date)
             self.assertIsNone(proj.end_date)
 
+    def test_blocked_when_external_consent_false(self):
+        """Returns 403 when external_consent is False on runtimeAppContext."""
+        self.mock_ctx.external_consent = False
+        self.mock_ctx.data_consent = True
+        resp = self.client.post("/resume/test_abc123/add/project/MyProject/ai")
+        self.assertEqual(resp.status_code, 403)
+
+    def test_blocked_when_data_consent_false(self):
+        """Returns 403 when data_consent is False on runtimeAppContext."""
+        self.mock_ctx.external_consent = True
+        self.mock_ctx.data_consent = False
+        resp = self.client.post("/resume/test_abc123/add/project/MyProject/ai")
+        self.assertEqual(resp.status_code, 403)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

> Consent form is now viewable to the user in the Settings Tab
> On opening the software for the first time it routes the user to the Settings tab and all consents are turned off
> Added local consent toggle and status and warnings for when consent is off
> If local consent is off only the home page and settings tab are viewable
> Added button for AI generation of Resume and Portfolio in Build tab
> Button is greyed out when external consent is off in settings

**Closes:** # (#558 )

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Automatic Testing: cd into frontend and then run npm run dev
> UI tests with playwrite: cd into front end and then run npx playwright test e2e/milestone3-flows.spec.js 2>&1

> Manual Testing: Go to Settings page . 
1. Toggle Local consent on and off (click save each time it's toggled). check that all tabs except home and settings page grey out and can't be navigated to when local consent is off and that when consent is toggled back on the text turns black again and tabs can be navigated to. Also check that red warning comes up below toggle when local consent is off. Also under consent settings header on the right the bar that says local processing should turn red and say Not allow when local consent is off and turn green and say allow when it's on
2. Toggle external consent on and off. Check that warning comes up and that bar under consent settings header that says external tools turns green and red like the local version
3. Turn off external consent and navigate to the builder tab. The Generate Resume with AI button should be to the left of the Generate Resume button. Add your name and template type and check that the Generate Resume button becomes active, but the Generate Resume with AI button does not (because consent is off)
4. Go to the portfolio part and do the same
5. Navigate back to the settings tab and turn external consent back on. Check that Generate Resume with AI button is active. Try generating an ai resume
6. go to the portfolio part and do the same

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->
Local and external consent both allowed:
<img width="1477" height="871" alt="image" src="https://github.com/user-attachments/assets/78dd2802-76dc-4cc7-a09f-b554c4d99823" />

local consent not allowed:
<img width="1485" height="905" alt="image" src="https://github.com/user-attachments/assets/9f184129-65e5-4743-b844-219b178c2180" />

external consent not allowed:
<img width="1482" height="897" alt="image" src="https://github.com/user-attachments/assets/5b7ea10f-cb93-4c68-892b-2f32c7020f53" />

Generate Resume button when consent is turned off:
<img width="715" height="472" alt="image" src="https://github.com/user-attachments/assets/1eb4ab8e-b1f0-4665-98a2-e08ef3a41ac8" />

Generate Resume button when consent is turned on:
<img width="705" height="460" alt="image" src="https://github.com/user-attachments/assets/a4caef2e-ab20-4178-8b96-05b6de7b771e" />


Tests:
<img width="755" height="319" alt="image" src="https://github.com/user-attachments/assets/fbcee6c0-83c2-481c-ad73-fce34ce4ec78" />

<img width="856" height="413" alt="image" src="https://github.com/user-attachments/assets/78deee0b-1569-45a6-bfc3-18182da0119f" />



</details>
