### PR TITLE
Add Global notifications

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1982,6 +1982,268 @@ input[type="radio"] {
 }
 
 /* ==========================================================================
+   Liquid Glass Notifications
+   ========================================================================== */
+.liquid-notify-layer {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 120;
+}
+
+.liquid-notify-stack {
+  position: fixed;
+  top: 0.9rem;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(92vw, 620px);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.liquid-toast {
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.62rem;
+  border-radius: 999px;
+  padding: 0.68rem 0.98rem;
+  color: var(--ink-0);
+  border: 1.5px solid rgba(0, 0, 0, 0.76);
+  background: color-mix(in srgb, var(--layer-status-card) 92%, #ffffff 8%);
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.12);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  font-weight: 580;
+  letter-spacing: 0;
+  transform: translate3d(0, -56px, 0) scale(0.96);
+  opacity: 0;
+  will-change: transform, opacity;
+  animation: liquid-toast-drop-in 560ms cubic-bezier(0.23, 1.03, 0.25, 1) both;
+}
+
+.liquid-toast::before {
+  content: none;
+}
+
+.liquid-toast.is-exit {
+  animation: liquid-toast-fall-out 700ms cubic-bezier(0.26, 0.62, 0.3, 1) forwards;
+}
+
+.liquid-toast-dot {
+  width: 0.56rem;
+  height: 0.56rem;
+  border-radius: 50%;
+  border: 1.5px solid rgba(0, 0, 0, 0.72);
+  background: #7d838d;
+  transform: none;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.55);
+}
+
+.liquid-toast--success {
+  border-color: color-mix(in srgb, var(--status-ok-accent) 74%, #000000 26%);
+  background: color-mix(in srgb, var(--status-ok-accent) 22%, var(--layer-status-card) 78%);
+  box-shadow: inset 3px 0 0 color-mix(in srgb, var(--status-ok-accent) 92%, #ffffff 8%), 0 10px 20px rgba(0, 0, 0, 0.14);
+}
+
+.liquid-toast--warning {
+  border-color: color-mix(in srgb, var(--status-row-accent) 72%, #000000 28%);
+  background: color-mix(in srgb, var(--status-row-accent) 20%, var(--layer-status-card) 80%);
+  box-shadow: inset 3px 0 0 color-mix(in srgb, var(--status-row-accent) 92%, #ffffff 8%), 0 10px 20px rgba(0, 0, 0, 0.14);
+}
+
+.liquid-toast--error {
+  border-color: color-mix(in srgb, var(--status-missing-accent) 74%, #000000 26%);
+  background: color-mix(in srgb, var(--status-missing-accent) 20%, var(--layer-status-card) 80%);
+  box-shadow: inset 3px 0 0 color-mix(in srgb, var(--status-missing-accent) 92%, #ffffff 8%), 0 10px 20px rgba(0, 0, 0, 0.14);
+}
+
+.liquid-toast--success .liquid-toast-dot {
+  background: color-mix(in srgb, var(--status-ok-accent) 92%, #1d1d1f 8%);
+  border-color: rgba(0, 0, 0, 0.72);
+}
+
+.liquid-toast--warning .liquid-toast-dot {
+  background: color-mix(in srgb, var(--status-row-accent) 92%, #1d1d1f 8%);
+  border-color: rgba(0, 0, 0, 0.72);
+}
+
+.liquid-toast--error .liquid-toast-dot {
+  background: color-mix(in srgb, var(--status-missing-accent) 92%, #1d1d1f 8%);
+  border-color: rgba(0, 0, 0, 0.72);
+}
+
+.liquid-splash-zone {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0.8rem;
+  display: flex;
+  justify-content: center;
+}
+
+.liquid-splash {
+  position: absolute;
+  width: min(92vw, 380px);
+  height: 140px;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.liquid-splash .drop {
+  position: absolute;
+  bottom: 0;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--layer-status-card);
+  border: 1px solid #000000;
+  box-shadow: none;
+  will-change: transform, opacity;
+  animation: liquid-splash-rise 860ms linear forwards;
+}
+
+.liquid-splash--error .drop {
+  background: color-mix(in srgb, var(--status-missing-accent) 24%, var(--layer-status-card) 76%);
+  border-color: color-mix(in srgb, var(--status-missing-accent) 72%, #000000 28%);
+}
+
+.liquid-splash--warning .drop {
+  background: color-mix(in srgb, var(--status-row-accent) 22%, var(--layer-status-card) 78%);
+  border-color: color-mix(in srgb, var(--status-row-accent) 70%, #000000 30%);
+}
+
+.liquid-splash--success .drop {
+  background: color-mix(in srgb, var(--status-ok-accent) 24%, var(--layer-status-card) 76%);
+  border-color: color-mix(in srgb, var(--status-ok-accent) 72%, #000000 28%);
+}
+
+.liquid-splash .drop-1 {
+  left: 50%;
+  --dx: -138px;
+  --dy: -112px;
+}
+
+.liquid-splash .drop-2 {
+  left: 50%;
+  --dx: -92px;
+  --dy: -94px;
+  animation-delay: 35ms;
+}
+
+.liquid-splash .drop-3 {
+  left: 50%;
+  --dx: 0px;
+  --dy: -128px;
+  animation-delay: 58ms;
+}
+
+.liquid-splash .drop-4 {
+  left: 50%;
+  --dx: 96px;
+  --dy: -96px;
+  animation-delay: 35ms;
+}
+
+.liquid-splash .drop-5 {
+  left: 50%;
+  --dx: 142px;
+  --dy: -114px;
+}
+
+.liquid-splash .drop-6 {
+  left: 50%;
+  --dx: -62px;
+  --dy: -130px;
+  animation-delay: 78ms;
+}
+
+.liquid-splash .drop-7 {
+  left: 50%;
+  --dx: 60px;
+  --dy: -132px;
+  animation-delay: 78ms;
+}
+
+.liquid-splash .drop-8 {
+  left: 50%;
+  --dx: -176px;
+  --dy: -84px;
+  animation-delay: 12ms;
+}
+
+.liquid-splash .drop-9 {
+  left: 50%;
+  --dx: 178px;
+  --dy: -86px;
+  animation-delay: 12ms;
+}
+
+@keyframes liquid-toast-drop-in {
+  0% {
+    transform: translate3d(0, -76px, 0) scale(0.9);
+    opacity: 0;
+  }
+  78% {
+    transform: translate3d(0, 0, 0) scale(1.01);
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes liquid-toast-fall-out {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(0, calc(100dvh - 148px), 0) scale(0.7);
+    opacity: 0;
+  }
+}
+
+@keyframes liquid-splash-rise {
+  0% {
+    transform: translate(-50%, 0) scale(0.62);
+    opacity: 0.96;
+  }
+  60% {
+    transform: translate(calc(-50% + var(--dx, 0px)), var(--dy, -64px)) scale(1);
+    opacity: 0.86;
+  }
+  100% {
+    transform: translate(calc(-50% + var(--dx, 0px) * 1.46), calc(var(--dy, -64px) * 1.46)) scale(0.1);
+    opacity: 0;
+  }
+}
+
+[data-theme="dark"] .liquid-toast--error {
+  color: var(--status-missing-text);
+}
+
+.a11y-reduced-motion .liquid-toast {
+  animation: none !important;
+  transform: translate3d(0, 0, 0) scale(1) !important;
+  opacity: 1 !important;
+}
+
+.a11y-reduced-motion .liquid-toast.is-exit {
+  animation: none !important;
+  transition: opacity 180ms linear;
+  opacity: 0 !important;
+}
+
+.a11y-reduced-motion .liquid-splash .drop {
+  animation: none !important;
+}
+
+/* ==========================================================================
    Sub-card Blocks + Data Views
    ========================================================================== */
 .sub-card {

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2043,36 +2043,36 @@ input[type="radio"] {
 }
 
 .liquid-toast--success {
-  border-color: color-mix(in srgb, var(--status-ok-accent) 74%, #000000 26%);
-  background: color-mix(in srgb, var(--status-ok-accent) 22%, var(--layer-status-card) 78%);
-  box-shadow: inset 3px 0 0 color-mix(in srgb, var(--status-ok-accent) 92%, #ffffff 8%), 0 10px 20px rgba(0, 0, 0, 0.14);
+  border-color: #1d7f41;
+  background: #dff3e6;
+  box-shadow: inset 4px 0 0 #1d9b4f, 0 10px 20px rgba(0, 0, 0, 0.14);
 }
 
 .liquid-toast--warning {
-  border-color: color-mix(in srgb, var(--status-row-accent) 72%, #000000 28%);
-  background: color-mix(in srgb, var(--status-row-accent) 20%, var(--layer-status-card) 80%);
-  box-shadow: inset 3px 0 0 color-mix(in srgb, var(--status-row-accent) 92%, #ffffff 8%), 0 10px 20px rgba(0, 0, 0, 0.14);
+  border-color: #8f640f;
+  background: #faedcf;
+  box-shadow: inset 4px 0 0 #c6871a, 0 10px 20px rgba(0, 0, 0, 0.14);
 }
 
 .liquid-toast--error {
-  border-color: color-mix(in srgb, var(--status-missing-accent) 74%, #000000 26%);
-  background: color-mix(in srgb, var(--status-missing-accent) 20%, var(--layer-status-card) 80%);
-  box-shadow: inset 3px 0 0 color-mix(in srgb, var(--status-missing-accent) 92%, #ffffff 8%), 0 10px 20px rgba(0, 0, 0, 0.14);
+  border-color: #9d2a34;
+  background: #f8dfe3;
+  box-shadow: inset 4px 0 0 #d04654, 0 10px 20px rgba(0, 0, 0, 0.14);
 }
 
 .liquid-toast--success .liquid-toast-dot {
-  background: color-mix(in srgb, var(--status-ok-accent) 92%, #1d1d1f 8%);
-  border-color: rgba(0, 0, 0, 0.72);
+  background: #15833f;
+  border-color: #0f5e2c;
 }
 
 .liquid-toast--warning .liquid-toast-dot {
-  background: color-mix(in srgb, var(--status-row-accent) 92%, #1d1d1f 8%);
-  border-color: rgba(0, 0, 0, 0.72);
+  background: #b67610;
+  border-color: #7a4f0b;
 }
 
 .liquid-toast--error .liquid-toast-dot {
-  background: color-mix(in srgb, var(--status-missing-accent) 92%, #1d1d1f 8%);
-  border-color: rgba(0, 0, 0, 0.72);
+  background: #b62f3d;
+  border-color: #7f212a;
 }
 
 .liquid-splash-zone {
@@ -2107,18 +2107,18 @@ input[type="radio"] {
 }
 
 .liquid-splash--error .drop {
-  background: color-mix(in srgb, var(--status-missing-accent) 24%, var(--layer-status-card) 76%);
-  border-color: color-mix(in srgb, var(--status-missing-accent) 72%, #000000 28%);
+  background: #efc4cb;
+  border-color: #9d2a34;
 }
 
 .liquid-splash--warning .drop {
-  background: color-mix(in srgb, var(--status-row-accent) 22%, var(--layer-status-card) 78%);
-  border-color: color-mix(in srgb, var(--status-row-accent) 70%, #000000 30%);
+  background: #f3dbab;
+  border-color: #8f640f;
 }
 
 .liquid-splash--success .drop {
-  background: color-mix(in srgb, var(--status-ok-accent) 24%, var(--layer-status-card) 76%);
-  border-color: color-mix(in srgb, var(--status-ok-accent) 72%, #000000 28%);
+  background: #cbe8d3;
+  border-color: #1d7f41;
 }
 
 .liquid-splash .drop-1 {
@@ -2225,6 +2225,65 @@ input[type="radio"] {
 
 [data-theme="dark"] .liquid-toast--error {
   color: var(--status-missing-text);
+}
+
+[data-theme="dark"] .liquid-toast {
+  color: #eaf2ff;
+  border-color: rgba(220, 229, 242, 0.6);
+  background: #263241;
+}
+
+[data-theme="dark"] .liquid-toast-dot {
+  border-color: rgba(220, 229, 242, 0.68);
+  box-shadow: 0 0 0 2px rgba(15, 24, 35, 0.66);
+}
+
+[data-theme="dark"] .liquid-toast--success {
+  border-color: #3f9d62;
+  background: #1f3528;
+  box-shadow: inset 4px 0 0 #56bf7a, 0 10px 20px rgba(0, 0, 0, 0.28);
+}
+
+[data-theme="dark"] .liquid-toast--warning {
+  border-color: #be8a2f;
+  background: #3a2f1a;
+  box-shadow: inset 4px 0 0 #d9a342, 0 10px 20px rgba(0, 0, 0, 0.28);
+}
+
+[data-theme="dark"] .liquid-toast--error {
+  border-color: #c04c5a;
+  background: #3f232a;
+  box-shadow: inset 4px 0 0 #e16776, 0 10px 20px rgba(0, 0, 0, 0.28);
+}
+
+[data-theme="dark"] .liquid-toast--success .liquid-toast-dot {
+  background: #56bf7a;
+  border-color: #3f9d62;
+}
+
+[data-theme="dark"] .liquid-toast--warning .liquid-toast-dot {
+  background: #d9a342;
+  border-color: #be8a2f;
+}
+
+[data-theme="dark"] .liquid-toast--error .liquid-toast-dot {
+  background: #e16776;
+  border-color: #c04c5a;
+}
+
+[data-theme="dark"] .liquid-splash--success .drop {
+  background: #2f4f3a;
+  border-color: #56bf7a;
+}
+
+[data-theme="dark"] .liquid-splash--warning .drop {
+  background: #4a3b21;
+  border-color: #d9a342;
+}
+
+[data-theme="dark"] .liquid-splash--error .drop {
+  background: #4b2b33;
+  border-color: #e16776;
 }
 
 .a11y-reduced-motion .liquid-toast {

--- a/frontend/app/layout.js
+++ b/frontend/app/layout.js
@@ -1,4 +1,5 @@
 import "./globals.css";
+import LiquidGlassNotifier from "../components/LiquidGlassNotifier";
 
 /**
  * Root layout module metadata.
@@ -21,7 +22,10 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en" data-theme="light" style={{ colorScheme: "light" }} suppressHydrationWarning>
-      <body>{children}</body>
+      <body>
+        {children}
+        <LiquidGlassNotifier />
+      </body>
     </html>
   );
 }

--- a/frontend/components/LiquidGlassNotifier.jsx
+++ b/frontend/components/LiquidGlassNotifier.jsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const MESSAGE_SELECTOR = "p.error, p.success, p.warning";
+const DISPLAY_MS = 1600;
+const EXIT_MS = 700;
+const REDUCED_DISPLAY_MS = 2600;
+const REDUCED_EXIT_MS = 180;
+const SPLASH_CLEANUP_MS = 1600;
+const SPLASH_LEAD_MS = 120;
+const MAX_TOASTS = 6;
+
+function kindFromNode(node) {
+  if (node.classList.contains("error")) return "error";
+  if (node.classList.contains("warning")) return "warning";
+  return "success";
+}
+
+function dedupeKey(kind, text) {
+  return `${kind}::${text}`;
+}
+
+function isA11yReducedMotionEnabled() {
+  if (typeof document === "undefined") return false;
+  return document.documentElement.classList.contains("a11y-reduced-motion");
+}
+
+export default function LiquidGlassNotifier() {
+  const [toasts, setToasts] = useState([]);
+  const [splashes, setSplashes] = useState([]);
+
+  const scanScheduledRef = useRef(false);
+
+  const addToast = useCallback((kind, text) => {
+    const reducedMotion = isA11yReducedMotionEnabled();
+    const displayMs = reducedMotion ? REDUCED_DISPLAY_MS : DISPLAY_MS;
+    const exitMs = reducedMotion ? REDUCED_EXIT_MS : EXIT_MS;
+
+    const now = Date.now();
+
+    const id = `toast-${now}-${Math.random().toString(36).slice(2, 8)}`;
+    setToasts((prev) => {
+      const next = [...prev, { id, kind, text, phase: "enter" }];
+      return next.length > MAX_TOASTS ? next.slice(next.length - MAX_TOASTS) : next;
+    });
+
+    window.setTimeout(() => {
+      setToasts((prev) => prev.map((toast) => (
+        toast.id === id ? { ...toast, phase: "exit" } : toast
+      )));
+    }, displayMs);
+
+    if (!reducedMotion) {
+      window.setTimeout(() => {
+        if (isA11yReducedMotionEnabled()) return;
+        const splashId = `splash-${now}-${Math.random().toString(36).slice(2, 8)}`;
+        setSplashes((prev) => [...prev, { id: splashId, kind }]);
+
+        window.setTimeout(() => {
+          setSplashes((prev) => prev.filter((splash) => splash.id !== splashId));
+        }, SPLASH_CLEANUP_MS);
+      }, displayMs + Math.max(60, exitMs - SPLASH_LEAD_MS));
+    }
+
+    window.setTimeout(() => {
+      setToasts((prev) => prev.filter((toast) => toast.id !== id));
+    }, displayMs + exitMs);
+  }, []);
+
+  const scanMessages = useCallback(() => {
+    scanScheduledRef.current = false;
+
+    const nodes = document.querySelectorAll(MESSAGE_SELECTOR);
+
+    for (const node of nodes) {
+      if (!(node instanceof HTMLElement)) continue;
+      if (node.closest(".liquid-notify-layer")) continue;
+
+      const text = (node.textContent || "").trim();
+      if (!text) {
+        delete node.dataset.liquidGlassSignature;
+        continue;
+      }
+
+      const kind = kindFromNode(node);
+      const signature = dedupeKey(kind, text);
+      if (node.dataset.liquidGlassSignature === signature) continue;
+
+      addToast(kind, text);
+      node.dataset.liquidGlassSignature = signature;
+      node.setAttribute("aria-hidden", "true");
+      node.style.display = "none";
+    }
+  }, [addToast]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+
+    scanMessages();
+
+    const observer = new MutationObserver(() => {
+      if (scanScheduledRef.current) return;
+      scanScheduledRef.current = true;
+      window.requestAnimationFrame(scanMessages);
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      characterData: true,
+      subtree: true
+    });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [scanMessages]);
+
+  return (
+    <div className="liquid-notify-layer" aria-live="polite" aria-atomic="false">
+      <div className="liquid-notify-stack" role="status">
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            className={`liquid-toast liquid-toast--${toast.kind} ${toast.phase === "exit" ? "is-exit" : ""}`.trim()}
+          >
+            <span className="liquid-toast-dot" aria-hidden="true" />
+            <span>{toast.text}</span>
+          </div>
+        ))}
+      </div>
+
+      <div className="liquid-splash-zone" aria-hidden="true">
+        {splashes.map((splash) => (
+          <div key={splash.id} className={`liquid-splash liquid-splash--${splash.kind}`.trim()}>
+            <span className="drop drop-1" />
+            <span className="drop drop-2" />
+            <span className="drop drop-3" />
+            <span className="drop drop-4" />
+            <span className="drop drop-5" />
+            <span className="drop drop-6" />
+            <span className="drop drop-7" />
+            <span className="drop drop-8" />
+            <span className="drop drop-9" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/scripts/ensure-canonical-files.mjs
+++ b/frontend/scripts/ensure-canonical-files.mjs
@@ -9,7 +9,7 @@
  * This script runs in npm pre-hooks and restores expected canonical names
  * before dev/build/start to keep routing and imports stable.
  */
-import { readdirSync, renameSync, existsSync } from "node:fs";
+import { readdirSync, renameSync, existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
 /**
@@ -57,6 +57,7 @@ function restoreCanonical({ dirPath, canonicalName, fallbackPattern }) {
  */
 const appDir = join(process.cwd(), "app");
 const componentsDir = join(process.cwd(), "components");
+const nextBuildDir = join(process.cwd(), ".next");
 
 restoreCanonical({
   dirPath: join(appDir, "upload"),
@@ -75,3 +76,10 @@ restoreCanonical({
   canonicalName: "LiquidShell.jsx",
   fallbackPattern: /^LiquidShell \d+\.jsx$/
 });
+
+// Clear stale build artifacts before dev/build/start to avoid intermittent
+// route-file ENOENT issues in .next/server/app/* during hot reload.
+if (existsSync(nextBuildDir)) {
+  rmSync(nextBuildDir, { recursive: true, force: true });
+  console.log("[fix] cleared stale .next build cache");
+}

--- a/frontend/scripts/ensure-canonical-files.mjs
+++ b/frontend/scripts/ensure-canonical-files.mjs
@@ -58,6 +58,7 @@ function restoreCanonical({ dirPath, canonicalName, fallbackPattern }) {
 const appDir = join(process.cwd(), "app");
 const componentsDir = join(process.cwd(), "components");
 const nextBuildDir = join(process.cwd(), ".next");
+const lifecycleEvent = process.env.npm_lifecycle_event || "";
 
 restoreCanonical({
   dirPath: join(appDir, "upload"),
@@ -77,9 +78,9 @@ restoreCanonical({
   fallbackPattern: /^LiquidShell \d+\.jsx$/
 });
 
-// Clear stale build artifacts before dev/build/start to avoid intermittent
-// route-file ENOENT issues in .next/server/app/* during hot reload.
-if (existsSync(nextBuildDir)) {
+// Clear stale build artifacts only for predev to avoid removing a valid
+// production build right before `next start`.
+if (lifecycleEvent === "predev" && existsSync(nextBuildDir)) {
   rmSync(nextBuildDir, { recursive: true, force: true });
   console.log("[fix] cleared stale .next build cache");
 }


### PR DESCRIPTION
## 📝 Description
Implemented based on peer testing feedback (notification visibility)
- Implemented a global notification system that captures existing inline error/success/warning messages and renders them as stacked toasts with splash transitions.  
- Also added reduced motion handling so animation heavy effects are minimized for accessibility users.  
- In addition, updated the frontend pre-run canonical script to clear stale  .next artifacts that caused intermittent ENOENT route build errors during local development.

This change centralizes feedback UX across pages, improves consistency, and stabilizes frontend dev runtime behavior.

Dependencies: no new package dependencies added.

**Closes:** #641

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [x] ⚡ Performance improvement

---

## 🧪 Testing

- [x] Ran `npm --prefix frontend test` (all tests passing locally)
- [x] Manually validated notification behavior on `/config`, `/upload`, and repeated button clicks (including reduced motion mode)

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<img width="488" height="57" alt="image" src="https://github.com/user-attachments/assets/ccdf4b9f-70db-4a69-ad2e-d151e2371231" />
